### PR TITLE
fix: correct spelling of referrer in header

### DIFF
--- a/.changeset/giant-shrimps-call.md
+++ b/.changeset/giant-shrimps-call.md
@@ -1,0 +1,8 @@
+---
+'@plait/core': patch
+---
+
+correctly move operation and move reverse logic
+
+
+


### PR DESCRIPTION
BREAKING CHANGE: Rather than using misspelled Referer as name of header, instead use correct spelling Referrer. Clients expecting Referer will no longer receive that header  and will presumably not honor the new Referrer until updated to support this new name for this header.