### PR TITLE
feat(mind): refactor mind plugin type and be compatible with legacy data

### DIFF
--- a/.changeset/cuddly-crabs-strive.md
+++ b/.changeset/cuddly-crabs-strive.md
@@ -1,0 +1,9 @@
+---
+'@plait/mind': minor
+---
+
+fix two issues:
+1. fix getTopicMaxDynamicWidth issue get wrong width when manualWidth exists.
+2. fix height issue when resize mind node width or update image size.
+
+refactor rename mind type to 'mind' and set type for child node to 'mind_child' and be compatible with legacy data.

--- a/packages/mind/src/constants/node-topic-style.ts
+++ b/packages/mind/src/constants/node-topic-style.ts
@@ -3,7 +3,3 @@ export const TOPIC_FONT_SIZE = 14;
 export const ROOT_TOPIC_FONT_SIZE = 18;
 
 export const TOPIC_DEFAULT_MAX_WORD_COUNT = 34;
-
-export const NodeTopicThreshold = {
-    defaultTextMaxWidth: 34 * 14
-};

--- a/packages/mind/src/interfaces/element.ts
+++ b/packages/mind/src/interfaces/element.ts
@@ -1,13 +1,11 @@
 import { isIndentedLayout, MindLayoutType } from '@plait/layouts';
-import { isNullOrUndefined, NODE_TO_PARENT, Path, PlaitBoard, PlaitElement, PlaitNode, Point } from '@plait/core';
+import { NODE_TO_PARENT, Path, PlaitBoard, PlaitElement, PlaitNode, Point } from '@plait/core';
 import { MindQueries } from '../queries';
-import { ELEMENT_TO_NODE } from '../utils';
 import { BaseData, EmojiData, ImageData } from './element-data';
 import { StrokeStyle } from '@plait/common';
+import { MIND_ELEMENT_TO_NODE } from '../utils/weak-maps';
 
-export interface MindElement<T = BaseData> extends PlaitElement {
-    data: T;
-    children: MindElement[];
+export interface BaseMindElement extends PlaitElement {
     rightNodeCount?: number;
     manualWidth?: number;
     isRoot?: boolean;
@@ -32,14 +30,22 @@ export interface MindElement<T = BaseData> extends PlaitElement {
     end?: number;
 }
 
-export interface PlaitMind extends MindElement {
-    type: 'mindmap';
+const LEGACY_MIND_TYPE = 'mindmap';
+
+export interface MindElement<T = BaseData> extends BaseMindElement {
+    type: 'mind_child' | 'mind' | 'mindmap';
+    children: MindElement[];
+    data: T;
+}
+
+export interface PlaitMind<T = BaseData> extends MindElement<T> {
+    type: 'mind' | 'mindmap';
     points: Point[];
 }
 
 export const PlaitMind = {
     isMind: (value: any): value is PlaitMind => {
-        return value.type === 'mindmap';
+        return value.type === 'mind' || value.type === LEGACY_MIND_TYPE;
     }
 };
 
@@ -53,7 +59,7 @@ export const MindElement = {
         return isIndentedLayout(_layout);
     },
     isMindElement(board: PlaitBoard | null, element: PlaitElement): element is MindElement {
-        if (element.data && element.data.topic) {
+        if ((element.data && element.data.topic) || element.type === 'mind_child') {
             return true;
         } else {
             return false;
@@ -89,7 +95,7 @@ export const MindElement = {
         return parents;
     },
     getNode(element: MindElement) {
-        const node = ELEMENT_TO_NODE.get(element);
+        const node = MIND_ELEMENT_TO_NODE.get(element);
         if (!node) {
             throw new Error(`can not get node from ${JSON.stringify(element)}`);
         }

--- a/packages/mind/src/mind-node.component.ts
+++ b/packages/mind/src/mind-node.component.ts
@@ -4,7 +4,7 @@ import { RoughSVG } from 'roughjs/bin/svg';
 import { MindElement, PlaitMind } from './interfaces/element';
 import { MindNode } from './interfaces/node';
 import { MindQueries } from './queries';
-import { ELEMENT_TO_NODE } from './utils/weak-maps';
+import { MIND_ELEMENT_TO_NODE } from './utils/weak-maps';
 import { drawAbstractLink } from './utils/draw/node-link/abstract-link';
 import { NodeEmojisGenerator } from './generators/node-emojis.generator';
 import { MindTransforms } from './transforms';
@@ -210,8 +210,8 @@ export class MindNodeComponent
         this.nodeEmojisGenerator.destroy();
         this.imageGenerator.destroy();
         this.activeGenerator.destroy();
-        if (ELEMENT_TO_NODE.get(this.element) === this.node) {
-            ELEMENT_TO_NODE.delete(this.element);
+        if (MIND_ELEMENT_TO_NODE.get(this.element) === this.node) {
+            MIND_ELEMENT_TO_NODE.delete(this.element);
         }
         this.getRef().destroyTextManage();
     }

--- a/packages/mind/src/mind.component.ts
+++ b/packages/mind/src/mind.component.ts
@@ -2,7 +2,7 @@ import { PlaitMind } from './interfaces/element';
 import { MindNode } from './interfaces/node';
 import { BeforeContextChange, PlaitPluginElementContext, depthFirstRecursion, isDebug } from '@plait/core';
 import { GlobalLayout, OriginNode } from '@plait/layouts';
-import { ELEMENT_TO_NODE } from './utils/weak-maps';
+import { MIND_ELEMENT_TO_NODE } from './utils/weak-maps';
 import { MindNodeComponent } from './mind-node.component';
 import { getLayoutOptions } from './utils/space/layout-options';
 import { getDefaultLayout } from './utils/layout';
@@ -39,7 +39,7 @@ export class PlaitMindComponent extends MindNodeComponent implements BeforeConte
         depthFirstRecursion<MindNode>(this.root, (node) => {
             node.x = node.x - offsetX + element.points[0][0];
             node.y = node.y - offsetY + element.points[0][1];
-            ELEMENT_TO_NODE.set(node.origin, node);
+            MIND_ELEMENT_TO_NODE.set(node.origin, node);
         });
     }
 }

--- a/packages/mind/src/plugins/with-node-resize.ts
+++ b/packages/mind/src/plugins/with-node-resize.ts
@@ -56,9 +56,7 @@ export const withNodeResize = (board: PlaitBoard) => {
             }
             const newTarget = PlaitNode.get<MindElement>(board, targetElementRef!.path);
             if (newTarget && NodeSpace.getNodeTopicMinWidth(board as PlaitMindBoard, newTarget) !== resizedWidth) {
-                targetElementRef!.textManage.updateRectangleWidth(resizedWidth);
-                const { height } = targetElementRef!.textManage.getSize(undefined, resizedWidth);
-                MindTransforms.setNodeManualWidth(board as PlaitMindBoard, newTarget, resizedWidth, height);
+                MindTransforms.setNodeManualWidth(board as PlaitMindBoard, newTarget, resizedWidth);
             }
         },
         afterResize: (resizeRef: ResizeRef<MindElement, null>) => {

--- a/packages/mind/src/transforms/image.ts
+++ b/packages/mind/src/transforms/image.ts
@@ -1,35 +1,22 @@
 import { PlaitBoard, Transforms } from '@plait/core';
 import { ImageData, MindElement } from '../interfaces';
 import { removeImageFocus } from '../utils/node/image';
-import { NodeSpace } from '../utils/space/node-space';
-import { PlaitMindBoard } from '../plugins/with-mind.board';
-import { getNewNodeHeight } from '../utils/node/dynamic-width';
 import { CommonImageItem } from '@plait/common';
 
 export const removeImage = (board: PlaitBoard, element: MindElement<ImageData>) => {
     removeImageFocus(board, element);
     const newElement = {
-        data: { ...element.data }
+        data: { ...element.data, topic: { ...element.data.topic } }
     } as MindElement;
     delete newElement.data.image;
     const path = PlaitBoard.findPath(board, element);
-    const newDynamicWidth = NodeSpace.getNodeNewDynamicWidth(board as PlaitMindBoard, element, 0);
-    const newHeight = getNewNodeHeight(board as PlaitMindBoard, element, newDynamicWidth);
-    if (newHeight) {
-        newElement.height = newHeight;
-    }
     Transforms.setNode(board, newElement, path);
 };
 
 export const setImage = (board: PlaitBoard, element: MindElement, imageItem: CommonImageItem) => {
     const newElement = {
-        data: { ...element.data, image: imageItem }
+        data: { ...element.data, image: imageItem, topic: { ...element.data.topic } }
     };
-    const newDynamicWidth = NodeSpace.getNodeNewDynamicWidth(board as PlaitMindBoard, element, imageItem.width);
-    const newHeight = getNewNodeHeight(board as PlaitMindBoard, element, newDynamicWidth);
-    if (newHeight) {
-        (newElement as MindElement).height = newHeight;
-    }
     const path = PlaitBoard.findPath(board, element);
     Transforms.setNode(board, newElement, path);
 };

--- a/packages/mind/src/transforms/node.ts
+++ b/packages/mind/src/transforms/node.ts
@@ -20,10 +20,10 @@ export const setTopic = (board: PlaitMindBoard, element: MindElement, topic?: El
     Transforms.setNode(board, newElement, path);
 };
 
-export const setNodeManualWidth = (board: PlaitMindBoard, element: MindElement, width: number, height: number) => {
+export const setNodeManualWidth = (board: PlaitMindBoard, element: MindElement, width: number) => {
     const path = PlaitBoard.findPath(board, element);
-    const { width: normalizedWidth } = normalizeWidthAndHeight(board, element, width, height);
-    const newElement = { manualWidth: normalizedWidth } as MindElement;
+    const { width: normalizedWidth } = normalizeWidthAndHeight(board, element, width, 0);
+    const newElement = { manualWidth: normalizedWidth, data: { ...element.data, topic: { ...element.data.topic } } } as MindElement;
     Transforms.setNode(board, newElement, path);
 };
 

--- a/packages/mind/src/utils/clipboard.ts
+++ b/packages/mind/src/utils/clipboard.ts
@@ -9,7 +9,6 @@ import { adjustAbstractToNode, adjustNodeToRoot, adjustRootToNode } from './node
 import { Element } from 'slate';
 import { findNewChildNodePath } from './path';
 import { PlaitMindBoard } from '../plugins/with-mind.board';
-import { getTopicSize } from './common';
 
 export const buildClipboardData = (board: PlaitBoard, selectedElements: MindElement[], startPoint: Point) => {
     let result: MindElement[] = [];
@@ -76,9 +75,6 @@ export const insertClipboardData = (
         if (hasTargetParent && operationType !== WritableClipboardOperationType.duplicate) {
             if (item.isRoot) {
                 newElement = adjustRootToNode(board, newElement);
-                const { width, height } = getTopicSizeByElement(board, newElement, targetParent as MindElement);
-                newElement.width = width;
-                newElement.height = height;
             }
             // handle abstract start and end
             if (AbstractNode.isAbstract(newElement)) {
@@ -94,9 +90,6 @@ export const insertClipboardData = (
             }
             if (!item.isRoot) {
                 newElement = adjustNodeToRoot(board, newElement);
-                const { width, height } = getTopicSizeByElement(board, newElement);
-                newElement.width = width;
-                newElement.height = height;
             }
             path = [board.children.length];
         }
@@ -111,14 +104,4 @@ export const insertClipboardText = (board: PlaitMindBoard, targetParent: PlaitEl
     const newElement = createMindElement(text, {});
     Transforms.insertNode(board, newElement, findNewChildNodePath(board, targetParent));
     Transforms.addSelectionWithTemporaryElements(board, [newElement]);
-};
-
-export const getTopicSizeByElement = (board: PlaitBoard, element: MindElement, parentElement?: MindElement) => {
-    return getTopicSize(
-        board,
-        PlaitMind.isMind(element),
-        (parentElement && PlaitMind.isMind(parentElement)) || false,
-        element.data.topic,
-        element.manualWidth
-    );
 };

--- a/packages/mind/src/utils/common.ts
+++ b/packages/mind/src/utils/common.ts
@@ -1,7 +1,5 @@
 import { getI18nValue, PlaitBoard } from '@plait/core';
 import { MindI18nKey } from '../constants/default';
-import { ROOT_TOPIC_FONT_SIZE, TOPIC_DEFAULT_MAX_WORD_COUNT, TOPIC_FONT_SIZE } from '../constants';
-import { DEFAULT_FONT_FAMILY, measureElement, ParagraphElement } from '@plait/common';
 
 export const MIND_CENTRAL_TEXT = '中心主题';
 
@@ -13,17 +11,4 @@ export const getDefaultMindNameText = (board: PlaitBoard) => {
 
 export const getAbstractNodeText = (board: PlaitBoard) => {
     return getI18nValue(board, MindI18nKey.abstractNodeText, ABSTRACT_NODE_TEXT);
-};
-
-export const getTopicSize = (board: PlaitBoard | null, isRoot: boolean, isBranch: boolean, topic: ParagraphElement, manualWidth?: number) => {
-    let fontFamily = DEFAULT_FONT_FAMILY;
-    let fontSize = TOPIC_FONT_SIZE;
-    if (isRoot) {
-        fontFamily = DEFAULT_FONT_FAMILY;
-        fontSize = ROOT_TOPIC_FONT_SIZE;
-    } else if (isBranch) {
-        fontFamily = DEFAULT_FONT_FAMILY;
-    }
-    const maxWidth = fontSize * TOPIC_DEFAULT_MAX_WORD_COUNT;
-    return measureElement(board, topic, { fontSize, fontFamily }, manualWidth ? manualWidth : maxWidth);
 };

--- a/packages/mind/src/utils/mind.ts
+++ b/packages/mind/src/utils/mind.ts
@@ -5,7 +5,6 @@ import { createMindElement, INHERIT_ATTRIBUTE_KEYS, InheritAttribute } from './n
 import { MindNode } from '../interfaces/node';
 import { PlaitMindBoard } from '../plugins/with-mind.board';
 import { ROOT_TOPIC_FONT_SIZE, TOPIC_FONT_SIZE } from '../constants/node-topic-style';
-import { TEXT_DEFAULT_HEIGHT } from '@plait/text-plugins';
 
 export const getChildrenCount = (element: MindElement) => {
     const count: number = element.children.reduce((p: number, c: MindElement) => {

--- a/packages/mind/src/utils/node/adjust-node.ts
+++ b/packages/mind/src/utils/node/adjust-node.ts
@@ -8,7 +8,7 @@ export const adjustRootToNode = (board: PlaitBoard, node: MindElement) => {
     const newNode: MindElement = { ...node };
     delete newNode.isRoot;
     delete newNode.rightNodeCount;
-    delete newNode.type;
+    newNode.type = 'mind_child';
     if (newNode.layout === MindLayoutType.standard) {
         delete newNode.layout;
     }
@@ -19,7 +19,6 @@ export const adjustAbstractToNode = (node: MindElement) => {
     const newNode: MindElement = { ...node };
     delete newNode.start;
     delete newNode.end;
-
     return newNode;
 };
 
@@ -37,6 +36,6 @@ export const adjustNodeToRoot = (board: PlaitMindBoard, node: MindElement): Mind
         ...newElement,
         layout: newElement.layout ?? MindLayoutType.right,
         isRoot: true,
-        type: 'mindmap'
+        type: 'mind'
     };
 };

--- a/packages/mind/src/utils/node/create-node.ts
+++ b/packages/mind/src/utils/node/create-node.ts
@@ -11,7 +11,7 @@ export const createEmptyMind = (board: PlaitBoard, point: Point) => {
     const text = getDefaultMindNameText(board);
     const element = createMindElement(text, { layout: MindLayoutType.right });
     element.isRoot = true;
-    element.type = 'mindmap';
+    element.type = 'mind';
     const width = NodeSpace.getNodeWidth(board as PlaitMindBoard, element);
     const height = NodeSpace.getNodeHeight(board as PlaitMindBoard, element);
     element.points = [[point[0] - width / 2, point[1] - height / 2]];
@@ -21,6 +21,7 @@ export const createEmptyMind = (board: PlaitBoard, point: Point) => {
 export const createMindElement = (text: string | Element, options: InheritAttribute) => {
     const newElement: MindElement = {
         id: idCreator(),
+        type: 'mind_child',
         data: {
             topic: buildText(text)
         },

--- a/packages/mind/src/utils/normalize.ts
+++ b/packages/mind/src/utils/normalize.ts
@@ -1,4 +1,3 @@
-import { isNullOrUndefined } from '@plait/core';
 import { MindElement } from '../interfaces/element';
 import { ParagraphElement } from '@plait/common';
 

--- a/packages/mind/src/utils/position/image.ts
+++ b/packages/mind/src/utils/position/image.ts
@@ -9,7 +9,6 @@ import { RESIZE_HANDLE_DIAMETER, getRectangleResizeHandleRefs } from '@plait/com
 export function getImageForeignRectangle(board: PlaitMindBoard, element: MindElement<ImageData>): RectangleClient {
     let { x, y } = getRectangleByNode(MindElement.getNode(element));
     const elementWidth = element.manualWidth || element.width;
-
     x =
         elementWidth > element.data.image.width
             ? x + NodeSpace.getTextLeftSpace(board, element) + (elementWidth - element.data.image.width) / 2

--- a/packages/mind/src/utils/position/node.ts
+++ b/packages/mind/src/utils/position/node.ts
@@ -3,6 +3,7 @@ import { MindNode } from '../../interfaces/node';
 import { MindElement } from '../../interfaces/element';
 import { NodeSpace } from '../space/node-space';
 import { PlaitMindBoard } from '../../plugins/with-mind.board';
+import { MIND_ELEMENT_TO_NODE } from '../weak-maps';
 
 export function getRectangleByNode(node: MindNode): RectangleClient {
     const x = node.x + node.hGap;
@@ -30,7 +31,7 @@ export function getRectangleByElement(board: PlaitMindBoard, element: MindElemen
 }
 
 export function isHitMindElement(board: PlaitBoard, point: Point, element: MindElement) {
-    const node = MindElement.getNode(element);
+    const node = MIND_ELEMENT_TO_NODE.get(element);
     if (node && distanceBetweenPointAndRectangle(point[0], point[1], getRectangleByNode(node)) === 0) {
         return true;
     } else {

--- a/packages/mind/src/utils/space/node-space.ts
+++ b/packages/mind/src/utils/space/node-space.ts
@@ -9,8 +9,8 @@ import { getStrokeWidthByElement } from '../node-style/shape';
 import { getDefaultFontSizeForMindElement } from '../mind';
 import { DEFAULT_FONT_SIZE, MarkTypes, PlaitMarkEditor } from '@plait/text-plugins';
 import { DEFAULT_FONT_FAMILY, getElementSize } from '@plait/common';
-import { NodeTopicThreshold } from '../../constants/node-topic-style';
 import { PlaitBoard } from '@plait/core';
+import { TOPIC_DEFAULT_MAX_WORD_COUNT } from '../../constants';
 
 const NodeDefaultSpace = {
     horizontal: {
@@ -105,18 +105,11 @@ export const NodeSpace = {
         return normalizedSize.height;
     },
     getTopicMaxDynamicWidth(board: PlaitMindBoard, element: MindElement) {
-        return Math.max(
-            NodeTopicThreshold.defaultTextMaxWidth,
-            element.manualWidth || 0,
-            MindElement.hasImage(element) ? element.data.image?.width : 0
-        );
-    },
-    /**
-     * use it when upload image first or resize image
-     */
-    getNodeNewDynamicWidth(board: PlaitMindBoard, element: MindElement, imageWidth: number) {
-        const width = element.manualWidth || element.width;
-        return Math.max(width, imageWidth);
+        const fontSize = getDefaultFontSizeForMindElement(element);
+        if (element.manualWidth) {
+            return Math.max(element.manualWidth, MindElement.hasImage(element) ? element.data.image?.width : 0);
+        }
+        return Math.max(fontSize * TOPIC_DEFAULT_MAX_WORD_COUNT, MindElement.hasImage(element) ? element.data.image?.width : 0);
     },
     getNodeResizableMinWidth(board: PlaitMindBoard, element: MindElement) {
         const minTopicWidth = NodeSpace.getNodeTopicMinWidth(board, element);

--- a/packages/mind/src/utils/weak-maps.ts
+++ b/packages/mind/src/utils/weak-maps.ts
@@ -1,4 +1,4 @@
 import { MindElement } from '../interfaces/element';
 import { MindNode } from '../interfaces/node';
 
-export const ELEMENT_TO_NODE = new WeakMap<MindElement, MindNode>();
+export const MIND_ELEMENT_TO_NODE = new WeakMap<MindElement, MindNode>();

--- a/src/app/editor/mock-data.ts
+++ b/src/app/editor/mock-data.ts
@@ -20,13 +20,14 @@ import { PlaitDrawElement } from '@plait/draw';
 // 基础思维导图数据结构
 export const mockMindData: PlaitMind[] = [
     {
-        type: 'mindmap',
+        type: 'mind',
         id: '1',
         rightNodeCount: 3,
         data: { topic: { children: [{ text: '脑图调研' }] }, emojis: [{ name: '🏀' }, { name: '🌈' }] },
         children: [
             {
                 id: '1-1',
+                type: 'mind_child',
                 data: {
                     topic: { children: [{ text: '富文本' }] },
                     emojis: [{ name: '🤩' }, { name: '🤘' }],
@@ -42,10 +43,12 @@ export const mockMindData: PlaitMind[] = [
             },
             {
                 id: '1-4',
+                type: 'mind_child',
                 data: { topic: { children: [{ text: '知名脑图产品' }] } },
                 children: [
                     {
                         id: '1-4-1',
+                        type: 'mind_child',
                         data: { topic: { children: [{ text: '布局算法' }] } },
                         children: [],
                         width: 56,
@@ -53,10 +56,12 @@ export const mockMindData: PlaitMind[] = [
                     },
                     {
                         id: '1-4-2',
+                        type: 'mind_child',
                         data: { topic: { children: [{ text: 'non-layered-tidy-trees' }] } },
                         children: [
                             {
                                 id: '1-4-2-1',
+                                type: 'mind_child',
                                 data: { topic: { children: [{ text: '鱼骨图哦' }] } },
                                 children: [],
                                 width: 56,
@@ -64,6 +69,7 @@ export const mockMindData: PlaitMind[] = [
                             },
                             {
                                 id: '1-4-2-2',
+                                type: 'mind_child',
                                 data: { topic: { children: [{ text: '缩进布局' }] } },
                                 children: [],
                                 width: 56,
@@ -75,6 +81,7 @@ export const mockMindData: PlaitMind[] = [
                     },
                     {
                         id: '1-4-3',
+                        type: 'mind_child',
                         data: { topic: { children: [{ text: '知名脑图产品' }] } },
                         children: [],
                         width: 84,
@@ -86,10 +93,12 @@ export const mockMindData: PlaitMind[] = [
             },
             {
                 id: '1-5',
+                type: 'mind_child',
                 data: { topic: { children: [{ text: 'xxxxxxx' }] } },
                 children: [
                     {
                         id: '1-5-1',
+                        type: 'mind_child',
                         data: { topic: { children: [{ text: '鱼骨图哦' }] } },
                         children: [],
                         width: 56,
@@ -97,6 +106,7 @@ export const mockMindData: PlaitMind[] = [
                     },
                     {
                         id: '1-5-2',
+                        type: 'mind_child',
                         data: { topic: { children: [{ text: '缩进布局' }] } },
                         children: [],
                         width: 56,


### PR DESCRIPTION
This pull request will define mind plugin type as `mind` and set child node type to `mind_child` and be compatible with legacy data.
After this pr judge PlaitMind and MindElement will be more easy and readable for new contributor or ai.
And fix two issues:
1. fix getTopicMaxDynamicWidth issue get wrong width when manualWidth exists.
2. fix height issue when resize mind node width or update image size.