### PR TITLE
refactor(mind): remove isRoot property #1080

### DIFF
--- a/.changeset/loose-otters-behave.md
+++ b/.changeset/loose-otters-behave.md
@@ -1,0 +1,5 @@
+---
+'@plait/mind': minor
+---
+
+remove isRoot property since it is same with `type === 'mind'`

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -47,7 +47,6 @@ const demoData = [
     rightNodeCount: 3,
     data: { topic: { children: [{ text: '思维导图' }] } },
     children: [],
-    isRoot: true,
     points: [[560, 700]],
   },
 ] as PlaitElement[];

--- a/docs/guides/intro.md
+++ b/docs/guides/intro.md
@@ -88,7 +88,6 @@ const demoData = [
     rightNodeCount: 3,
     data: { topic: { children: [{ text: '思维导图' }] } },
     children: [],
-    isRoot: true,
     points: [[560, 700]],
   },
 ] as PlaitElement[];

--- a/packages/mind/src/generators/node-more.generator.ts
+++ b/packages/mind/src/generators/node-more.generator.ts
@@ -296,7 +296,7 @@ export const getMoreStartAndEnd = (board: PlaitBoard, element: MindElement, link
     // underline shape and horizontal
     const layout = MindQueries.getLayoutByElement(element) as MindLayoutType;
     const isHorizontal = isHorizontalLayout(layout);
-    if (isHorizontal && isUnderlineShape && !element.isRoot) {
+    if (isHorizontal && isUnderlineShape && !PlaitMind.isMind(element)) {
         placement[1] = VerticalPlacement.bottom;
     }
     let startPoint = getPointByPlacement(nodeClient, placement);

--- a/packages/mind/src/interfaces/element.ts
+++ b/packages/mind/src/interfaces/element.ts
@@ -8,7 +8,6 @@ import { MIND_ELEMENT_TO_NODE } from '../utils/weak-maps';
 export interface BaseMindElement extends PlaitElement {
     rightNodeCount?: number;
     manualWidth?: number;
-    isRoot?: boolean;
 
     // node style attributes
     fill?: string;

--- a/packages/mind/src/plugins/with-mind.ts
+++ b/packages/mind/src/plugins/with-mind.ts
@@ -90,14 +90,14 @@ export const withMind = (baseBoard: PlaitBoard) => {
     };
 
     board.canAddToGroup = (element: PlaitElement) => {
-        if (MindElement.isMindElement(board, element) && !element.isRoot) {
+        if (MindElement.isMindElement(board, element) && !PlaitMind.isMind(element)) {
             return false;
         }
         return canAddToGroup(element);
     };
 
     board.canSetZIndex = (element: PlaitElement) => {
-        if (MindElement.isMindElement(board, element) && !element.isRoot) {
+        if (MindElement.isMindElement(board, element) && !PlaitMind.isMind(element)) {
             return false;
         }
         return canSetZIndex(element);
@@ -137,7 +137,7 @@ export const withMind = (baseBoard: PlaitBoard) => {
     };
 
     board.isMovable = (element) => {
-        if (PlaitMind.isMind(element) && element.isRoot) {
+        if (PlaitMind.isMind(element)) {
             return true;
         }
         return isMovable(element);
@@ -151,7 +151,7 @@ export const withMind = (baseBoard: PlaitBoard) => {
     };
 
     board.isAlign = (element: PlaitElement) => {
-        if (PlaitMind.isMind(element) && element.isRoot) {
+        if (PlaitMind.isMind(element)) {
             return true;
         }
         return isAlign(element);

--- a/packages/mind/src/plugins/with-node-dnd.ts
+++ b/packages/mind/src/plugins/with-node-dnd.ts
@@ -68,7 +68,7 @@ export const withNodeDnd = (board: PlaitBoard) => {
             !AbstractNode.isAbstract(hitElement)
         ) {
             const targetElements = selectedElements.filter(
-                element => MindElement.isMindElement(board, element) && !element.isRoot && !AbstractNode.isAbstract(element)
+                (element) => MindElement.isMindElement(board, element) && !PlaitMind.isMind(element) && !AbstractNode.isAbstract(element)
             ) as MindElement[];
             const isMultipleSelection = selectedElements.length > 0 && selectedElements.includes(hitElement);
             if (isMultipleSelection) {
@@ -111,10 +111,10 @@ export const withNodeDnd = (board: PlaitBoard) => {
             const offsetY = endPoint[1] - startPoint[1];
             dragFakeNodeG?.remove();
             dragFakeNodeG = createG();
-            [...activeElements, ...correspondingElements].forEach(element => {
+            [...activeElements, ...correspondingElements].forEach((element) => {
                 addActiveOnDragOrigin(element);
             });
-            activeElements.forEach(element => {
+            activeElements.forEach((element) => {
                 const nodeG = drawFakeDragNode(board, element, offsetX, offsetY);
                 dragFakeNodeG?.appendChild(nodeG);
             });
@@ -131,7 +131,7 @@ export const withNodeDnd = (board: PlaitBoard) => {
         if (!board.options.readonly && firstLevelElements.length) {
             firstLevelElements.push(...correspondingElements);
             if (isDragging(board)) {
-                firstLevelElements.forEach(element => {
+                firstLevelElements.forEach((element) => {
                     removeActiveOnDragOrigin(element);
                 });
             }
@@ -141,8 +141,8 @@ export const withNodeDnd = (board: PlaitBoard) => {
                 const targetElementPathRef = board.pathRef(PlaitBoard.findPath(board, dropTarget.target));
                 let abstractRefs = getValidAbstractRefs(board, firstLevelElements);
                 const normalElements = firstLevelElements
-                    .filter(element => !abstractRefs.some(refs => refs.abstract === element))
-                    .map(element => {
+                    .filter((element) => !abstractRefs.some((refs) => refs.abstract === element))
+                    .map((element) => {
                         if (AbstractNode.isAbstract(element)) {
                             return adjustAbstractToNode(element);
                         }
@@ -156,7 +156,7 @@ export const withNodeDnd = (board: PlaitBoard) => {
                     const targetHasCorrespondAbstract =
                         correspondingAbstract && correspondingAbstract.end !== targetPath[targetPath.length - 1] - 1;
                     if (targetHasCorrespondAbstract) {
-                        const adjustedNode = abstractRefs.map(ref => {
+                        const adjustedNode = abstractRefs.map((ref) => {
                             return adjustAbstractToNode(ref.abstract);
                         });
                         normalElements.push(...adjustedNode);
@@ -210,8 +210,8 @@ export const withNodeDnd = (board: PlaitBoard) => {
                 targetPathRef.unref();
 
                 let setActiveElements: MindElement[] = [];
-                depthFirstRecursion((board as unknown) as MindElement, node => {
-                    const isSelected = activeElements.some(element => element.id === node.id);
+                depthFirstRecursion(board as unknown as MindElement, (node) => {
+                    const isSelected = activeElements.some((element) => element.id === node.id);
                     if (isSelected) {
                         setActiveElements.push(node);
                     }

--- a/packages/mind/src/testing/data/basic.ts
+++ b/packages/mind/src/testing/data/basic.ts
@@ -24,7 +24,6 @@ export const getTestingChildren = (): MindElement[] => {
                     end: 1
                 }
             ],
-            isRoot: true,
             points: [[1117, 590]],
             isCollapsed: false
         }

--- a/packages/mind/src/utils/clipboard.ts
+++ b/packages/mind/src/utils/clipboard.ts
@@ -73,7 +73,7 @@ export const insertClipboardData = (
     elements.forEach((item: PlaitElement, index: number) => {
         newElement = copyNewNode(item as MindElement);
         if (hasTargetParent && operationType !== WritableClipboardOperationType.duplicate) {
-            if (item.isRoot) {
+            if (PlaitMind.isMind(item)) {
                 newElement = adjustRootToNode(board, newElement);
             }
             // handle abstract start and end
@@ -88,7 +88,7 @@ export const insertClipboardData = (
             if (AbstractNode.isAbstract(item)) {
                 newElement = adjustAbstractToNode(newElement);
             }
-            if (!item.isRoot) {
+            if (!PlaitMind.isMind(item)) {
                 newElement = adjustNodeToRoot(board, newElement);
             }
             path = [board.children.length];

--- a/packages/mind/src/utils/dnd/detector.ts
+++ b/packages/mind/src/utils/dnd/detector.ts
@@ -17,10 +17,10 @@ import { isBottomLayout, isRightLayout, isLeftLayout, AbstractNode } from '@plai
 import { isChildElement } from '../mind';
 
 export const directionCorrector = (board: PlaitBoard, node: MindNode, detectResults: DetectResult[]): DetectResult[] | null => {
-    if (!node.origin.isRoot && !AbstractNode.isAbstract(node.origin)) {
+    if (!PlaitMind.isMind(node.origin) && !AbstractNode.isAbstract(node.origin)) {
         const parentLayout = MindQueries.getCorrectLayoutByElement(board, node?.parent.origin as MindElement);
         if (isStandardLayout(parentLayout)) {
-            const idx = node.parent.children.findIndex(x => x === node);
+            const idx = node.parent.children.findIndex((x) => x === node);
             const isLeft = idx >= (node.parent.origin.rightNodeCount || 0);
             return getAllowedDirection(detectResults, [isLeft ? 'right' : 'left']);
         }
@@ -68,8 +68,8 @@ export const directionCorrector = (board: PlaitBoard, node: MindNode, detectResu
 
 export const getAllowedDirection = (detectResults: DetectResult[], illegalDirections: DetectResult[]): DetectResult[] | null => {
     const directions = detectResults;
-    illegalDirections.forEach(item => {
-        const bottomDirectionIndex = directions.findIndex(direction => direction === item);
+    illegalDirections.forEach((item) => {
+        const bottomDirectionIndex = directions.findIndex((direction) => direction === item);
         if (bottomDirectionIndex !== -1) {
             directions.splice(bottomDirectionIndex, 1);
         }
@@ -85,8 +85,8 @@ export const detectDropTarget = (
 ) => {
     let detectResult: DetectResult[] | null = null;
     depthFirstRecursion(
-        (board as unknown) as MindElement,
-        element => {
+        board as unknown as MindElement,
+        (element) => {
             if (!MindElement.isMindElement(board, element) || detectResult) {
                 return;
             }
@@ -96,7 +96,7 @@ export const detectDropTarget = (
                 detectResult = directionCorrector(board, node, directions);
             }
             dropTarget = null;
-            const isValid = activeElements.every(element => isValidTarget(element, node.origin));
+            const isValid = activeElements.every((element) => isValidTarget(element, node.origin));
             if (detectResult && isValid) {
                 dropTarget = { target: node.origin, detectResult: detectResult[0] };
             }

--- a/packages/mind/src/utils/draw/node-link/logic-link.ts
+++ b/packages/mind/src/utils/draw/node-link/logic-link.ts
@@ -5,7 +5,7 @@ import { getRectangleByNode, getShapeByElement, getStrokeStyleByElement } from '
 import { getLayoutDirection, getPointByPlacement, transformPlacement } from '../../point-placement';
 import { HorizontalPlacement, PointPlacement, VerticalPlacement } from '../../../interfaces/types';
 import { getBranchColorByMindElement, getBranchShapeByMindElement, getBranchWidthByMindElement } from '../../node-style/branch';
-import { BranchShape, MindElementShape } from '../../../interfaces/element';
+import { BranchShape, MindElementShape, PlaitMind } from '../../../interfaces/element';
 import { getStrokeLineDash, moveXOfPoint, StrokeStyle } from '@plait/common';
 
 export function drawLogicLink(
@@ -21,7 +21,7 @@ export function drawLogicLink(
     const branchColor = defaultStrokeColor || getBranchColorByMindElement(board, node.origin);
     const branchWidth = defaultStrokeWidth || getBranchWidthByMindElement(board, node.origin);
     const strokeStyle = defaultStrokeStyle || getStrokeStyleByElement(board, node.origin);
-    const hasStraightLine = branchShape === BranchShape.polyline ? true : !parent.origin.isRoot;
+    const hasStraightLine = branchShape === BranchShape.polyline ? true : !PlaitMind.isMind(parent.origin);
     const parentShape = getShapeByElement(board, parent.origin);
     const shape = getShapeByElement(board, node.origin);
     const hasUnderlineShape = shape === MindElementShape.underline;
@@ -39,7 +39,7 @@ export function drawLogicLink(
     transformPlacement(endPlacement, linkDirection);
 
     // underline shape and horizontal
-    if (isHorizontal && hasUnderlineShapeOfParent && !parent.origin.isRoot) {
+    if (isHorizontal && hasUnderlineShapeOfParent && !PlaitMind.isMind(parent.origin)) {
         beginPlacement[1] = VerticalPlacement.bottom;
     }
     if (isHorizontal && hasUnderlineShape) {

--- a/packages/mind/src/utils/mind.ts
+++ b/packages/mind/src/utils/mind.ts
@@ -59,7 +59,7 @@ export const copyNewNode = (node: MindElement) => {
 
 export const insertMindElement = (board: PlaitMindBoard, inheritNode: MindElement, path: Path) => {
     const newNode: InheritAttribute = {};
-    if (!inheritNode.isRoot) {
+    if (!PlaitMind.isMind(inheritNode)) {
         INHERIT_ATTRIBUTE_KEYS.forEach((attr) => {
             (newNode as any)[attr] = inheritNode[attr];
         });

--- a/packages/mind/src/utils/node-style/shape.ts
+++ b/packages/mind/src/utils/node-style/shape.ts
@@ -36,7 +36,7 @@ export const getFillByElement = (board: PlaitBoard, element: MindElement) => {
         return element.fill;
     }
     const defaultRootFill = getMindThemeColor(board).rootFill;
-    return element.isRoot ? defaultRootFill : DefaultNodeStyle.shape.fill;
+    return PlaitMind.isMind(element) ? defaultRootFill : DefaultNodeStyle.shape.fill;
 };
 
 export const getShapeByElement = (board: PlaitBoard, element: MindElement): MindElementShape => {

--- a/packages/mind/src/utils/node/adjust-node.ts
+++ b/packages/mind/src/utils/node/adjust-node.ts
@@ -6,7 +6,6 @@ import { PlaitMindBoard } from '../../plugins/with-mind.board';
 
 export const adjustRootToNode = (board: PlaitBoard, node: MindElement) => {
     const newNode: MindElement = { ...node };
-    delete newNode.isRoot;
     delete newNode.rightNodeCount;
     newNode.type = 'mind_child';
     if (newNode.layout === MindLayoutType.standard) {
@@ -35,7 +34,6 @@ export const adjustNodeToRoot = (board: PlaitMindBoard, node: MindElement): Mind
     return {
         ...newElement,
         layout: newElement.layout ?? MindLayoutType.right,
-        isRoot: true,
         type: 'mind'
     };
 };

--- a/packages/mind/src/utils/node/create-node.ts
+++ b/packages/mind/src/utils/node/create-node.ts
@@ -10,7 +10,6 @@ import { getDefaultMindNameText } from '../common';
 export const createEmptyMind = (board: PlaitBoard, point: Point) => {
     const text = getDefaultMindNameText(board);
     const element = createMindElement(text, { layout: MindLayoutType.right });
-    element.isRoot = true;
     element.type = 'mind';
     const width = NodeSpace.getNodeWidth(board as PlaitMindBoard, element);
     const height = NodeSpace.getNodeHeight(board as PlaitMindBoard, element);

--- a/packages/mind/src/utils/node/right-node-count.ts
+++ b/packages/mind/src/utils/node/right-node-count.ts
@@ -1,14 +1,14 @@
 import { Path, PlaitBoard, PlaitNode } from '@plait/core';
-import { MindElement } from '../../interfaces/element';
+import { MindElement, PlaitMind } from '../../interfaces/element';
 import { getRootLayout } from '../layout';
 import { MindLayoutType } from '@plait/layouts';
 
 export const isInRightBranchOfStandardLayout = (selectedElement: MindElement) => {
     const parentElement = MindElement.findParent(selectedElement);
     if (parentElement) {
-        const nodeIndex: number = parentElement.children.findIndex(item => item.id === selectedElement.id);
+        const nodeIndex: number = parentElement.children.findIndex((item) => item.id === selectedElement.id);
         if (
-            parentElement.isRoot &&
+            PlaitMind.isMind(parentElement) &&
             getRootLayout(parentElement) === MindLayoutType.standard &&
             parentElement.rightNodeCount &&
             nodeIndex <= parentElement.rightNodeCount - 1
@@ -30,7 +30,7 @@ export const insertElementHandleRightNodeCount = (
     insertCount: number,
     effectedRightNodeCount: RightNodeCountRef[] = []
 ) => {
-    let index = effectedRightNodeCount.findIndex(ref => Path.equals(ref.path, path));
+    let index = effectedRightNodeCount.findIndex((ref) => Path.equals(ref.path, path));
     const mind = PlaitNode.get(board, path) as MindElement;
     if (index === -1) {
         effectedRightNodeCount.push({ path, rightNodeCount: mind.rightNodeCount! + insertCount });
@@ -45,11 +45,11 @@ export const deleteElementsHandleRightNodeCount = (
     deletableElements: MindElement[],
     effectedRightNodeCount: RightNodeCountRef[] = []
 ) => {
-    deletableElements.forEach(element => {
+    deletableElements.forEach((element) => {
         if (isInRightBranchOfStandardLayout(element)) {
             const mind = MindElement.getParent(element);
             const path = PlaitBoard.findPath(board, mind);
-            let index = effectedRightNodeCount.findIndex(ref => Path.equals(ref.path, path));
+            let index = effectedRightNodeCount.findIndex((ref) => Path.equals(ref.path, path));
             if (index === -1) {
                 effectedRightNodeCount.push({ path, rightNodeCount: mind.rightNodeCount! - 1 });
             } else {

--- a/packages/mind/src/utils/space/layout-options.ts
+++ b/packages/mind/src/utils/space/layout-options.ts
@@ -7,7 +7,7 @@ import {
     isHorizontalLogicLayout,
     isIndentedLayout
 } from '@plait/layouts';
-import { MindElement, MindElementShape } from '../../interfaces/element';
+import { MindElement, MindElementShape, PlaitMind } from '../../interfaces/element';
 import { BASE } from '../../constants/default';
 import { getRootLayout } from '../layout';
 import { NodeSpace } from './node-space';
@@ -15,7 +15,7 @@ import { PlaitMindBoard } from '../../plugins/with-mind.board';
 
 export const getLayoutOptions = (board: PlaitMindBoard) => {
     function getMainAxle(element: MindElement, parent?: LayoutNode) {
-        if (element.isRoot) {
+        if (PlaitMind.isMind(element)) {
             return BASE * 12;
         }
         if (parent && parent.isRoot()) {
@@ -25,7 +25,7 @@ export const getLayoutOptions = (board: PlaitMindBoard) => {
     }
 
     function getSecondAxle(element: MindElement, parent?: LayoutNode) {
-        if (element.isRoot) {
+        if (PlaitMind.isMind(element)) {
             return BASE * 12;
         }
         return BASE * 8.5;

--- a/src/app/editor/mock-data.ts
+++ b/src/app/editor/mock-data.ts
@@ -103,7 +103,6 @@ export const mockMindData: PlaitMind[] = [
                 ]
             }
         ],
-        isRoot: true,
         points: [[560, 360]]
     }
 ];


### PR DESCRIPTION
This pull request remove isRoot property since it can be distinguished by `type === 'mind'`.
1. replace element.isRoot with PlaitMInd.isMind(element)
2. Removing isRoot definement from BaseMindElement
3. Removing other using scene