### PR TITLE
 refactor: remove rxjs from plait/common、plait/core

### DIFF
--- a/.changeset/lovely-wasps-make.md
+++ b/.changeset/lovely-wasps-make.md
@@ -1,0 +1,8 @@
+---
+'@plait/common': patch
+'@plait/core': patch
+---
+
+Remove rxjs independency from plait/common、plait/core
+
+Redraw group's boundary in onChange, which was handled by onStable mechanism (use rxjs). Since it need be handle after all others elements be handled.

--- a/packages/angular-board/src/board/board.component.ts
+++ b/packages/angular-board/src/board/board.component.ts
@@ -510,7 +510,6 @@ export class PlaitBoardComponent implements BoardComponentInterface, OnInit, OnC
 
     private updateListRender() {
         this.listRender.update(this.board.children, this.initializeChildrenContext());
-        PlaitBoard.getBoardContext(this.board).nextStable();
     }
 
     private initializeChildrenContext(): PlaitChildrenContext {

--- a/packages/common/src/core/group.component.ts
+++ b/packages/common/src/core/group.component.ts
@@ -1,21 +1,9 @@
-import {
-    OnContextChanged,
-    PlaitBoard,
-    PlaitGroup,
-    PlaitPluginElementContext,
-    getElementsInGroup,
-    getRectangleByGroup,
-    isSelectedElementOrGroup,
-    isSelectionMoving
-} from '@plait/core';
+import { OnContextChanged, PlaitBoard, PlaitGroup, PlaitPluginElementContext, getRectangleByGroup, isSelectionMoving } from '@plait/core';
 import { GroupGenerator } from '../generators/group.generator';
 import { ActiveGenerator, createActiveGenerator } from '../generators';
 import { CommonElementFlavour } from './element-flavour';
-import { Subscription } from 'rxjs';
 
 export class GroupComponent extends CommonElementFlavour<PlaitGroup, PlaitBoard> implements OnContextChanged<PlaitGroup, PlaitBoard> {
-    onStableSubscription?: Subscription;
-
     constructor() {
         super();
     }
@@ -36,28 +24,16 @@ export class GroupComponent extends CommonElementFlavour<PlaitGroup, PlaitBoard>
             }
         });
         this.groupGenerator = new GroupGenerator(this.board);
+        this.getRef().addGenerator(GroupGenerator.key, this.groupGenerator);
     }
 
     initialize(): void {
         super.initialize();
         this.initializeGenerator();
-        const contextService = PlaitBoard.getBoardContext(this.board);
-        this.onStableSubscription = contextService.onStable().subscribe(() => {
-            const elementsInGroup = getElementsInGroup(this.board, this.element, false, true);
-            const isPartialSelectGroup =
-                elementsInGroup.some(item => isSelectedElementOrGroup(this.board, item)) &&
-                !elementsInGroup.every(item => isSelectedElementOrGroup(this.board, item));
-            this.groupGenerator.processDrawing(this.element, this.getElementG(), isPartialSelectGroup);
-        });
     }
 
     onContextChanged(
         value: PlaitPluginElementContext<PlaitGroup, PlaitBoard>,
         previous: PlaitPluginElementContext<PlaitGroup, PlaitBoard>
     ) {}
-
-    destroy(): void {
-        super.destroy();
-        this.onStableSubscription?.unsubscribe();
-    }
 }

--- a/packages/common/src/generators/group.generator.ts
+++ b/packages/common/src/generators/group.generator.ts
@@ -3,6 +3,8 @@ import { Options } from 'roughjs/bin/core';
 import { Generator } from './generator';
 
 export class GroupGenerator extends Generator<PlaitGroup> {
+    static key = 'GroupGenerator';
+
     canDraw(element: PlaitGroup): boolean {
         return true;
     }

--- a/packages/common/src/plugins/with-group.ts
+++ b/packages/common/src/plugins/with-group.ts
@@ -23,11 +23,15 @@ import {
     PlaitPointerType,
     WritableClipboardOperationType,
     throttleRAF,
-    isMovingElements
+    isMovingElements,
+    getAllGroups,
+    isSelectedElementOrGroup
 } from '@plait/core';
 import { GroupComponent } from '../core/group.component';
 import { isKeyHotkey } from 'is-hotkey';
 import { isResizing } from '../utils';
+import { PlaitCommonElementRef } from '../core';
+import { GroupGenerator } from '../generators/group.generator';
 
 export function withGroup(board: PlaitBoard) {
     let groupRectangleG: SVGGElement | null;
@@ -42,7 +46,8 @@ export function withGroup(board: PlaitBoard) {
         deleteFragment,
         getRelatedFragment,
         getRectangle,
-        keyDown
+        keyDown,
+        onChange
     } = board;
 
     board.drawElement = (context: PlaitPluginElementContext) => {
@@ -147,6 +152,22 @@ export function withGroup(board: PlaitBoard) {
             }
         }
         keyDown(event);
+    };
+
+    board.onChange = () => {
+        onChange();
+        const groups = getAllGroups(board);
+        groups.forEach((group) => {
+            const elementsInGroup = getElementsInGroup(board, group, false, true);
+            const isPartialSelectGroup =
+                elementsInGroup.some((item) => isSelectedElementOrGroup(board, item)) &&
+                !elementsInGroup.every((item) => isSelectedElementOrGroup(board, item));
+            const ref = PlaitElement.getElementRef<PlaitCommonElementRef>(group);
+            const g = PlaitElement.getElementG(group);
+            ref.getGenerator(GroupGenerator.key).processDrawing(group, g, isPartialSelectGroup);
+            console.log(group, 'group');
+        });
+        console.log('onChange');
     };
 
     return board;

--- a/packages/common/src/plugins/with-group.ts
+++ b/packages/common/src/plugins/with-group.ts
@@ -165,9 +165,7 @@ export function withGroup(board: PlaitBoard) {
             const ref = PlaitElement.getElementRef<PlaitCommonElementRef>(group);
             const g = PlaitElement.getElementG(group);
             ref.getGenerator(GroupGenerator.key).processDrawing(group, g, isPartialSelectGroup);
-            console.log(group, 'group');
         });
-        console.log('onChange');
     };
 
     return board;

--- a/packages/common/src/text/text-manage.ts
+++ b/packages/common/src/text/text-manage.ts
@@ -12,7 +12,6 @@ import {
     updateForeignObject,
     updateForeignObjectWidth
 } from '@plait/core';
-import { fromEvent, timer } from 'rxjs';
 import { Editor, Element, NodeEntry, Range, Text, Node, Transforms, Operation } from 'slate';
 import { PlaitTextBoard, TextPlugin } from './with-text';
 import { clearElementSizeCache, measureElement, updateElementSizeCache } from './text-measure';
@@ -120,19 +119,21 @@ export class TextManage {
         };
         this.textComponentRef.update(props);
         Transforms.select(this.editor, [0]);
-        const mousedown$ = fromEvent<MouseEvent>(document, 'mousedown').subscribe((event: MouseEvent) => {
+
+        // Pure JS event listeners replacing rxjs fromEvent/timer
+        const mouseDownHandler = (event: MouseEvent) => {
             const point = toViewBoxPoint(this.board, toHostPoint(this.board, event.x, event.y));
             const textRec = this.options.getRenderRectangle ? this.options.getRenderRectangle() : this.options.getRectangle();
             const clickInText = RectangleClient.isHit(RectangleClient.getRectangleByPoints([point, point]), textRec);
             const isAttached = (event.target as HTMLElement).closest('.plait-board-attached');
             if (!clickInText && !isAttached) {
                 // handle composition input state, like: Chinese IME Composition Input
-                timer(0).subscribe(() => {
+                setTimeout(() => {
                     exitCallback();
-                });
+                }, 0);
             }
-        });
-        const keydown$ = fromEvent<KeyboardEvent>(document, 'keydown').subscribe((event: KeyboardEvent) => {
+        };
+        const keyDownHandler = (event: KeyboardEvent) => {
             if (event.isComposing) {
                 return;
             }
@@ -142,12 +143,12 @@ export class TextManage {
                 exitCallback();
                 return;
             }
-        });
+        };
         const exitCallback = () => {
             if (this.isEditing) {
                 this.updateRectangle();
-                mousedown$.unsubscribe();
-                keydown$.unsubscribe();
+                document.removeEventListener('mousedown', mouseDownHandler);
+                document.removeEventListener('keydown', keyDownHandler);
                 IS_TEXT_EDITABLE.set(this.board, false);
                 MERGING.set(this.board, false);
                 callback && callback();
@@ -159,8 +160,10 @@ export class TextManage {
                 this.exitCallback = undefined;
             }
         };
+        document.addEventListener('mousedown', mouseDownHandler);
+        document.addEventListener('keydown', keyDownHandler);
         this.exitCallback = exitCallback;
-        return exitCallback;
+         return exitCallback;
     }
 
     getSize = (element?: Element, maxWidth?: number) => {

--- a/packages/common/src/text/text-manage.ts
+++ b/packages/common/src/text/text-manage.ts
@@ -120,7 +120,6 @@ export class TextManage {
         this.textComponentRef.update(props);
         Transforms.select(this.editor, [0]);
 
-        // Pure JS event listeners replacing rxjs fromEvent/timer
         const mouseDownHandler = (event: MouseEvent) => {
             const point = toViewBoxPoint(this.board, toHostPoint(this.board, event.x, event.y));
             const textRec = this.options.getRenderRectangle ? this.options.getRenderRectangle() : this.options.getRectangle();
@@ -163,7 +162,7 @@ export class TextManage {
         document.addEventListener('mousedown', mouseDownHandler);
         document.addEventListener('keydown', keyDownHandler);
         this.exitCallback = exitCallback;
-         return exitCallback;
+        return exitCallback;
     }
 
     getSize = (element?: Element, maxWidth?: number) => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,8 +3,7 @@
     "version": "0.86.0",
     "peerDependencies": {
         "immer": "^10.0.3",
-        "is-hotkey": "^0.2.0",
-        "rxjs": "^7.8.0"
+        "is-hotkey": "^0.2.0"
     },
     "dependencies": {
         "roughjs": "^4.5.2",

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1,9 +1,6 @@
-import { Subject } from 'rxjs';
 import { ImageEntry } from './interfaces/element';
 
 export class PlaitBoardContext {
-    private _stable = new Subject();
-
     private uploadingFiles: ImageEntry[] = [];
 
     getUploadingFile(url: string) {
@@ -16,13 +13,5 @@ export class PlaitBoardContext {
 
     removeUploadingFile(fileEntry: ImageEntry) {
         this.uploadingFiles = this.uploadingFiles.filter(file => file.url !== fileEntry.url);
-    }
-
-    onStable() {
-        return this._stable.asObservable();
-    }
-
-    nextStable() {
-        this._stable.next('');
     }
 }

--- a/packages/core/src/utils/group.ts
+++ b/packages/core/src/utils/group.ts
@@ -13,9 +13,9 @@ import { sortElements } from './position';
 
 export const getElementsInGroup = (board: PlaitBoard, group: PlaitGroup, recursion?: boolean, includeGroup?: boolean) => {
     let result: PlaitElement[] = [];
-    const elements = board.children.filter(value => (value as PlaitElement).groupId === group.id) as PlaitElement[];
+    const elements = board.children.filter((value) => (value as PlaitElement).groupId === group.id) as PlaitElement[];
     if (recursion) {
-        elements.forEach(item => {
+        elements.forEach((item) => {
             if (PlaitGroupElement.isGroup(item)) {
                 if (includeGroup) {
                     result.push(item);
@@ -26,7 +26,7 @@ export const getElementsInGroup = (board: PlaitBoard, group: PlaitGroup, recursi
             }
         });
     } else {
-        result = includeGroup ? elements : (elements.filter(item => !PlaitGroupElement.isGroup(item)) as PlaitElement[]);
+        result = includeGroup ? elements : (elements.filter((item) => !PlaitGroupElement.isGroup(item)) as PlaitElement[]);
     }
     return result;
 };
@@ -34,10 +34,10 @@ export const getElementsInGroup = (board: PlaitBoard, group: PlaitGroup, recursi
 export const getAllElementsInGroup = (board: PlaitBoard, group: PlaitGroup, recursion?: boolean, includeGroup?: boolean) => {
     const elementsInGroup = getElementsInGroup(board, group, recursion, includeGroup);
     const result: PlaitElement[] = [];
-    elementsInGroup.forEach(element => {
+    elementsInGroup.forEach((element) => {
         depthFirstRecursion(
             element,
-            node => {
+            (node) => {
                 result.push(node);
             },
             () => true
@@ -57,7 +57,7 @@ export const getGroupByElement = (
     recursion?: boolean,
     originElements?: PlaitElement[]
 ): PlaitGroup | PlaitGroup[] | null => {
-    const group = (originElements || board.children).find(item => item.id === element?.groupId);
+    const group = (originElements || board.children).find((item) => item.id === element?.groupId);
     if (!group) {
         return recursion ? [] : null;
     }
@@ -90,23 +90,28 @@ export const getElementsInGroupByElement = (board: PlaitBoard, element: PlaitEle
     }
 };
 
+export const getAllGroups = (board: PlaitBoard) => {
+    const elements = board.children;
+    return elements.filter((item) => PlaitGroupElement.isGroup(item));
+};
+
 export const isSelectedElementOrGroup = (board: PlaitBoard, element: PlaitElement, elements?: PlaitElement[]) => {
     const selectedElements = elements?.length ? elements : getSelectedElements(board);
     if (PlaitGroupElement.isGroup(element)) {
         return isSelectedAllElementsInGroup(board, element, elements);
     }
-    return selectedElements.map(item => item.id).includes(element.id);
+    return selectedElements.map((item) => item.id).includes(element.id);
 };
 
 export const isSelectedAllElementsInGroup = (board: PlaitBoard, group: PlaitGroup, elements?: PlaitElement[]) => {
     const selectedElements = elements?.length ? elements : getSelectedElements(board);
     const elementsInGroup = getElementsInGroup(board, group, true);
-    return elementsInGroup.every(item => selectedElements.map(element => element.id).includes(item.id));
+    return elementsInGroup.every((item) => selectedElements.map((element) => element.id).includes(item.id));
 };
 
 export const filterSelectedGroups = (board: PlaitBoard, groups: PlaitGroup[], elements?: PlaitElement[]): PlaitGroup[] => {
     const selectedGroups: PlaitGroup[] = [];
-    groups.forEach(item => {
+    groups.forEach((item) => {
         if (isSelectedElementOrGroup(board, item, elements)) {
             selectedGroups.push(item);
         }
@@ -117,10 +122,10 @@ export const filterSelectedGroups = (board: PlaitBoard, groups: PlaitGroup[], el
 export const getSelectedGroups = (board: PlaitBoard, elements?: PlaitElement[], originElements?: PlaitElement[]): PlaitGroup[] => {
     const highestSelectedGroups = getHighestSelectedGroups(board, elements, originElements);
     const groups: PlaitGroup[] = [];
-    highestSelectedGroups.forEach(item => {
+    highestSelectedGroups.forEach((item) => {
         groups.push(item);
         const elementsInGroup = getElementsInGroup(board, item, true, true);
-        groups.push(...(elementsInGroup.filter(item => PlaitGroupElement.isGroup(item)) as PlaitGroup[]));
+        groups.push(...(elementsInGroup.filter((item) => PlaitGroupElement.isGroup(item)) as PlaitGroup[]));
     });
     return groups;
 };
@@ -142,7 +147,7 @@ export const getHighestSelectedGroup = (
 export const getHighestSelectedGroups = (board: PlaitBoard, elements?: PlaitElement[], originElements?: PlaitElement[]): PlaitGroup[] => {
     let result: PlaitGroup[] = [];
     const selectedElements = elements?.length ? elements : getSelectedElements(board);
-    selectedElements.forEach(item => {
+    selectedElements.forEach((item) => {
         if (item.groupId) {
             const group = getHighestSelectedGroup(board, item, elements, originElements);
             if (group && !result.includes(group)) {
@@ -157,8 +162,8 @@ export const getSelectedIsolatedElements = (board: PlaitBoard, elements?: PlaitE
     let result: PlaitElement[] = [];
     const selectedElements = elements?.length ? elements : getSelectedElements(board);
     selectedElements
-        .filter(item => !PlaitGroupElement.isGroup(item))
-        .forEach(item => {
+        .filter((item) => !PlaitGroupElement.isGroup(item))
+        .forEach((item) => {
             if (!item.groupId) {
                 result.push(item);
             } else {
@@ -173,7 +178,7 @@ export const getSelectedIsolatedElements = (board: PlaitBoard, elements?: PlaitE
 
 export const getSelectedIsolatedElementsCanAddToGroup = (board: PlaitBoard, elements?: PlaitElement[]) => {
     const selectedIsolatedElements = getSelectedIsolatedElements(board, elements);
-    return selectedIsolatedElements.filter(item => board.canAddToGroup(item));
+    return selectedIsolatedElements.filter((item) => board.canAddToGroup(item));
 };
 
 export const getHighestSelectedElements = (board: PlaitBoard, elements?: PlaitElement[]) => {
@@ -181,11 +186,11 @@ export const getHighestSelectedElements = (board: PlaitBoard, elements?: PlaitEl
 };
 
 export const createGroupRectangleG = (board: PlaitBoard, elements: PlaitElement[]): SVGGElement | null => {
-    const selectedElementIds = getSelectedElements(board).map(item => item.id);
+    const selectedElementIds = getSelectedElements(board).map((item) => item.id);
     let groupRectangleG: SVGGElement | null = null;
     const isMoving = isSelectionMoving(board);
 
-    elements.forEach(item => {
+    elements.forEach((item) => {
         const isRender = (!selectedElementIds.includes(item.id) && !isMoving) || isMoving;
         if (item.groupId && isRender) {
             if (!groupRectangleG) {
@@ -222,16 +227,16 @@ export const createGroup = (groupId?: string): PlaitGroup => {
 };
 
 export const nonGroupInHighestSelectedElements = (elements: PlaitElement[]) => {
-    return elements.every(item => !item.groupId);
+    return elements.every((item) => !item.groupId);
 };
 
 export const hasSelectedElementsInSameGroup = (elements: PlaitElement[]) => {
-    return elements.every(item => item.groupId && item.groupId === elements[0].groupId);
+    return elements.every((item) => item.groupId && item.groupId === elements[0].groupId);
 };
 
 export const canAddGroup = (board: PlaitBoard, elements?: PlaitElement[]) => {
     const highestSelectedElements = getHighestSelectedElements(board, elements);
-    const rootElements = highestSelectedElements.filter(item => board.canAddToGroup(item));
+    const rootElements = highestSelectedElements.filter((item) => board.canAddToGroup(item));
     if (rootElements.length > 1) {
         return nonGroupInHighestSelectedElements(rootElements) || hasSelectedElementsInSameGroup(rootElements);
     }
@@ -264,7 +269,7 @@ export const moveElementsToNewPathAfterAddGroup = (board: PlaitBoard, selectedEl
     moveElements.pop();
     moveElementsToNewPath(
         board,
-        moveElements.map(element => {
+        moveElements.map((element) => {
             return {
                 element,
                 newPath


### PR DESCRIPTION
This pull request will remove rxjs from common and core packages.
Replace rxjs with pure js.
Redraw group's boundary in onChange, which was handled by onStable mechanism (use rxjs). Since it need be handle after all others elements be handled.