### PR TITLE
fix(geometry): making the `insertElement` will not change the state of pointer and select the element just created

### DIFF
--- a/.changeset/giant-camels-punch.md
+++ b/.changeset/giant-camels-punch.md
@@ -1,0 +1,5 @@
+---
+'@plait/draw': patch
+---
+
+making the insertElement will not change the state of pointer and select the element just created

--- a/package-lock.json
+++ b/package-lock.json
@@ -22438,7 +22438,7 @@
         },
         "packages/angular-board": {
             "name": "@plait/angular-board",
-            "version": "0.86.1",
+            "version": "0.86.2",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.0"
@@ -22450,7 +22450,7 @@
         },
         "packages/angular-text": {
             "name": "@plait/angular-text",
-            "version": "0.86.1",
+            "version": "0.86.2",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.0"
@@ -22466,7 +22466,7 @@
         },
         "packages/common": {
             "name": "@plait/common",
-            "version": "0.86.1",
+            "version": "0.87.0-next.0",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.0"
@@ -22474,7 +22474,7 @@
         },
         "packages/core": {
             "name": "@plait/core",
-            "version": "0.86.1",
+            "version": "0.87.0-next.0",
             "license": "MIT",
             "dependencies": {
                 "points-on-curve": "^1.0.0",
@@ -22488,7 +22488,7 @@
         },
         "packages/draw": {
             "name": "@plait/draw",
-            "version": "0.86.1",
+            "version": "0.87.0-next.0",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.0"
@@ -22496,7 +22496,7 @@
         },
         "packages/flow": {
             "name": "@plait/flow",
-            "version": "0.86.1",
+            "version": "0.87.0-next.0",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.0"
@@ -22504,7 +22504,7 @@
         },
         "packages/graph-viz": {
             "name": "@plait/graph-viz",
-            "version": "0.86.1",
+            "version": "0.87.0-next.0",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.0"
@@ -22517,7 +22517,7 @@
         },
         "packages/layouts": {
             "name": "@plait/layouts",
-            "version": "0.86.1",
+            "version": "0.87.0-next.0",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.0"
@@ -22525,7 +22525,7 @@
         },
         "packages/mind": {
             "name": "@plait/mind",
-            "version": "0.86.1",
+            "version": "0.87.0-next.0",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.0"
@@ -22533,7 +22533,7 @@
         },
         "packages/text-plugins": {
             "name": "@plait/text-plugins",
-            "version": "0.86.1",
+            "version": "0.87.0-next.0",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.0"

--- a/packages/draw/src/utils/common.ts
+++ b/packages/draw/src/utils/common.ts
@@ -89,8 +89,6 @@ export const insertElement = (board: PlaitBoard, element: PlaitBaseGeometry | Pl
     memorizeLatestShape(board, element.shape);
     Transforms.insertNode(board, element, [board.children.length]);
     clearSelectedElement(board);
-    addSelectedElement(board, element);
-    BoardTransforms.updatePointerType(board, PlaitPointerType.selection);
 };
 
 export const isDrawElementIncludeText = (element: PlaitDrawElement) => {


### PR DESCRIPTION
This PR fix issue https://github.com/plait-board/drawnix/issues/307

Update the npm package version from `0.86.1` to `0.86.2`.
Prevent the `insertElement` automatically change the state of pointer to selecting and automaticallly add select element for the element just created.