### PR TITLE
fix(bug): fix infinite `pendingNodesG` appear when holding alt key

### DIFF
--- a/packages/core/src/plugins/with-moving.ts
+++ b/packages/core/src/plugins/with-moving.ts
@@ -51,6 +51,9 @@ export function withMoving(board: PlaitBoard) {
             if (isKeyHotkey('option', event)) {
                 event.preventDefault();
                 if (startPoint && activeElements.length && !PlaitBoard.hasBeenTextEditing(board)) {
+                    if(pendingNodesG) {
+                        PlaitBoard.getElementTopHost(board).removeChild(pendingNodesG);
+                    }
                     pendingNodesG = drawPendingNodesG(board, activeElements, offsetX, offsetY);
                     pendingNodesG && PlaitBoard.getElementTopHost(board).append(pendingNodesG);
                 }


### PR DESCRIPTION
This PR fixes #1086

While holding the `alt` key, it will keep trigger the creation of `pendingNodesG`, lead to infinite `active-with-moving` `<g>` are created. This PR will detect if the pendingNodeG is created, delete the old one and make sure there's always only one `active-with-moving` is created at the same time