### PR TITLE
fix(core): preserve text color in exports

### DIFF
--- a/.changeset/free-taxis-switch.md
+++ b/.changeset/free-taxis-switch.md
@@ -1,0 +1,5 @@
+---
+'@plait/core': patch
+---
+
+preserve text color in exports

--- a/packages/core/src/utils/to-image.spec.ts
+++ b/packages/core/src/utils/to-image.spec.ts
@@ -1,0 +1,53 @@
+import { PlaitBoard, PlaitElement } from '../interfaces';
+import { BOARD_TO_ELEMENT_HOST, BOARD_TO_HOST, NODE_TO_G } from './weak-maps';
+import { toSvgData } from './to-image';
+
+describe('toSvgData', () => {
+    const svgNamespace = 'http://www.w3.org/2000/svg';
+
+    afterEach(() => {
+        document.querySelectorAll('[data-to-image-spec]').forEach((node) => node.remove());
+    });
+
+    it('preserves Slate text color styles when cloning export nodes', async () => {
+        const element = { id: 'text-color' } as PlaitElement;
+        const board = {
+            children: [element],
+            getRectangle: () => ({ x: 0, y: 0, width: 120, height: 40 })
+        } as unknown as PlaitBoard;
+        const svg = document.createElementNS(svgNamespace, 'svg');
+        const elementHost = document.createElementNS(svgNamespace, 'g');
+        const elementG = document.createElementNS(svgNamespace, 'g');
+        const foreignObject = document.createElementNS(svgNamespace, 'foreignObject');
+        const textNode = document.createElement('span');
+
+        textNode.setAttribute('data-slate-node', 'text');
+        textNode.style.fontSize = '16px';
+        textNode.style.color = 'rgb(255, 0, 0)';
+        textNode.textContent = 'colored text';
+        foreignObject.append(textNode);
+        elementG.append(foreignObject);
+        elementHost.append(elementG);
+        svg.setAttribute('data-to-image-spec', '');
+        svg.append(elementHost);
+        document.body.append(svg);
+
+        BOARD_TO_HOST.set(board, svg);
+        BOARD_TO_ELEMENT_HOST.set(board, {
+            lowerHost: document.createElementNS(svgNamespace, 'g'),
+            host: elementHost,
+            upperHost: document.createElementNS(svgNamespace, 'g'),
+            topHost: document.createElementNS(svgNamespace, 'g'),
+            activeHost: document.createElementNS(svgNamespace, 'g'),
+            container: document.createElement('div'),
+            viewportContainer: document.createElement('div')
+        });
+        NODE_TO_G.set(element, elementG);
+
+        const svgData = await toSvgData(board, { elements: [element] });
+        const exportedSvg = new DOMParser().parseFromString(svgData, 'image/svg+xml');
+        const exportedTextNode = exportedSvg.querySelector('[data-slate-node="text"]') as HTMLElement;
+
+        expect(exportedTextNode.style.color).toBe('rgb(255, 0, 0)');
+    });
+});

--- a/packages/core/src/utils/to-image.ts
+++ b/packages/core/src/utils/to-image.ts
@@ -109,7 +109,7 @@ function cloneCSSStyle<T extends HTMLElement>(nativeNode: T, clonedNode: T, styl
 function batchCloneCSSStyle(sourceNode: SVGGElement, cloneNode: SVGGElement, inlineStyleClassNames?: string, styleNames?: string[]) {
     // handle text style, Hardcoded to slate editor framework
     const textSelector = '[data-slate-node="text"]';
-    const textStyle = ['font-size', 'font-family', 'line-height', 'text-decoration', 'font-weight', 'font-style', 'word-break'];
+    const textStyle = ['font-size', 'font-family', 'line-height', 'text-decoration', 'font-weight', 'font-style', 'word-break', 'color'];
     const sourceTextNodes = Array.from(sourceNode.querySelectorAll(textSelector));
     const cloneTextNodes = Array.from(cloneNode.querySelectorAll(textSelector));
     sourceTextNodes.map((node, index) => {


### PR DESCRIPTION
## Summary

- Add `color` to the core text style allowlist used when cloning Slate text nodes for SVG/PNG export.
- Add a focused `toSvgData` regression spec to verify cloned Slate text preserves `color`.

## Validation

- `npm run test:core -- --watch=false --browsers=ChromeHeadlessCI --progress=false`
- `npm run build:core`
- `npm run build:web` in Drawnix with the locally built Plait core package.
- Joint local Drawnix validation: built Plait core, used it from Drawnix `develop`, cleared the Vite prebundle cache, then verified SVG export writes `color` onto the cloned Slate text node and PNG export renders colored text pixels.

Related to plait-board/drawnix#424 and plait-board/drawnix#434.