### PR TITLE
fix(draw): anchor auto-size text bounds

### DIFF
--- a/.changeset/text-points-depend.md
+++ b/.changeset/text-points-depend.md
@@ -1,0 +1,5 @@
+---
+'@plait/draw': patch
+---
+
+keep auto-size text points anchored by the first point

--- a/packages/draw/src/transforms/geometry-text.spec.ts
+++ b/packages/draw/src/transforms/geometry-text.spec.ts
@@ -1,0 +1,65 @@
+import { createTestingBoard, PlaitBoard } from '@plait/core';
+import { Alignment } from '@plait/common';
+import { DrawTransforms } from '.';
+import { BasicShapes, PlaitText } from '../interfaces';
+import { ShapeDefaultSpace } from '../constants';
+import { getTextRectangle } from '../utils';
+
+describe('geometry text transforms', () => {
+    let board: PlaitBoard;
+
+    const createTextElement = (align: Alignment, points: PlaitText['points'] = [
+        [100, 50],
+        [160, 70]
+    ]): PlaitText => ({
+        id: align,
+        type: 'geometry',
+        shape: BasicShapes.text,
+        angle: 0,
+        opacity: 1,
+        autoSize: true,
+        text: {
+            children: [{ text: 'text' }],
+            align
+        },
+        points
+    });
+
+    beforeEach(() => {
+        board = createTestingBoard([], []);
+    });
+
+    it('should keep the first point fixed when resizing right aligned auto-size text', () => {
+        const element = createTextElement(Alignment.right);
+        board.children = [element];
+
+        DrawTransforms.setTextSize(board, element, 80, 24);
+
+        expect((board.children[0] as PlaitText).points).toEqual([
+            [100, 50],
+            [100 + 80 + ShapeDefaultSpace.rectangleAndText * 2, 50 + 24]
+        ]);
+    });
+
+    it('should keep the first point fixed when resizing center aligned auto-size text', () => {
+        const element = createTextElement(Alignment.center);
+        board.children = [element];
+
+        DrawTransforms.setTextSize(board, element, 80, 24);
+
+        expect((board.children[0] as PlaitText).points).toEqual([
+            [100, 50],
+            [100 + 80 + ShapeDefaultSpace.rectangleAndText * 2, 50 + 24]
+        ]);
+    });
+
+    it('should render auto-size text rectangle by the first point only', () => {
+        const element = createTextElement(Alignment.left);
+        const elementWithDifferentEndPoint = createTextElement(Alignment.left, [
+            [100, 50],
+            [20, 120]
+        ]);
+
+        expect(getTextRectangle(board, elementWithDifferentEndPoint)).toEqual(getTextRectangle(board, element));
+    });
+});

--- a/packages/draw/src/transforms/geometry-text.ts
+++ b/packages/draw/src/transforms/geometry-text.ts
@@ -2,8 +2,7 @@ import { PlaitBoard, Point, Transforms, hasValidAngle, RectangleClient } from '@
 import { Element } from 'slate';
 import { PlaitDrawElement, PlaitGeometry } from '../interfaces';
 import { ShapeDefaultSpace } from '../constants';
-import { Alignment, getFirstTextEditor, resetPointsAfterResize } from '@plait/common';
-import { AlignEditor } from '@plait/text-plugins';
+import { resetPointsAfterResize } from '@plait/common';
 import { MIN_TEXT_WIDTH } from '../constants/text';
 
 const normalizePoints = (board: PlaitBoard, element: PlaitGeometry, width: number, height: number) => {
@@ -13,22 +12,8 @@ const normalizePoints = (board: PlaitBoard, element: PlaitGeometry, width: numbe
 
     if (autoSize) {
         const newWidth = width < MIN_TEXT_WIDTH ? MIN_TEXT_WIDTH : width;
-        const editor = getFirstTextEditor(element);
-        if (AlignEditor.isActive(editor, Alignment.right)) {
-            points = [
-                [points[1][0] - (newWidth + defaultSpace * 2), points[0][1]],
-                [points[1][0], points[0][1] + height]
-            ];
-        } else if (AlignEditor.isActive(editor, Alignment.center)) {
-            const oldWidth = Math.abs(points[0][0] - points[1][0]);
-            const offset = (newWidth - oldWidth) / 2;
-            points = [
-                [points[0][0] - offset - defaultSpace, points[0][1]],
-                [points[1][0] + offset + defaultSpace, points[0][1] + height]
-            ];
-        } else {
-            points = [points[0], [points[0][0] + newWidth + defaultSpace * 2, points[0][1] + height]];
-        }
+        const anchor: Point = [points[0][0], points[0][1]];
+        points = [anchor, [anchor[0] + newWidth + defaultSpace * 2, anchor[1] + height]];
         if (hasValidAngle(element)) {
             points = resetPointsAfterResize(
                 RectangleClient.getRectangleByPoints(element.points),

--- a/packages/draw/src/utils/common.ts
+++ b/packages/draw/src/utils/common.ts
@@ -61,11 +61,12 @@ export const getTextRectangle = <T extends PlaitElement = PlaitGeometry>(board: 
     const width = elementRectangle.width - ShapeDefaultSpace.rectangleAndText * 2 - strokeWidth * 2;
     const textSize = getTextSize(board, element.text, isAutoSize ? GeometryThreshold.defaultTextMaxWidth : width);
     if (isAutoSize) {
+        const anchor = element.points![0] as Point;
         return {
             height: textSize.height,
             width: textSize.width,
-            x: elementRectangle.x + ShapeDefaultSpace.rectangleAndText + strokeWidth,
-            y: elementRectangle.y + (elementRectangle.height - textSize.height) / 2
+            x: anchor[0] + ShapeDefaultSpace.rectangleAndText + strokeWidth,
+            y: anchor[1]
         };
     }
     return {


### PR DESCRIPTION
## Summary
- Render auto-size text bounds from `points[0]` and measured text size.
- Keep `points[0]` fixed when recalculating auto-size text points.
- Add regression coverage for `points[1]` independence.

Fixes #1121

## Tests
- `npx ng test draw --watch=false --progress=false --browsers=ChromeHeadlessCI`