### PR TITLE
feat(mind): navigate selected node with arrow keys

### DIFF
--- a/packages/mind/src/plugins/with-mind-hotkey.spec.ts
+++ b/packages/mind/src/plugins/with-mind-hotkey.spec.ts
@@ -1,25 +1,73 @@
 import {
+    DOWN_ARROW,
     ENTER,
+    LEFT_ARROW,
     Path,
     PlaitBoard,
     PlaitNode,
+    RIGHT_ARROW,
     SLASH,
     TAB,
+    UP_ARROW,
     addSelectedElement,
     clearNodeWeakMap,
     clearSelectedElement,
     createKeyboardEvent,
     createModModifierKeys,
     createTestingBoard,
-    fakeNodeWeakMap
+    fakeNodeWeakMap,
+    getSelectedElements
 } from '@plait/core';
 import { getTestingChildren } from '../testing/data/basic';
 import { withMindHotkey } from './with-mind-hotkey';
+import { PlaitMindBoard } from './with-mind.board';
 import { createMindElement } from '../utils';
-import { MindElement } from '@plait/mind';
+import { MindElement, PlaitMind } from '@plait/mind';
+import { fakeMindLayout, clearLayoutNodeWeakMap } from '../testing/core/fake-layout-node';
+import { MindNode } from '../interfaces';
+
+const createNavigationTestingChildren = (): MindElement[] => [
+    {
+        type: 'mind',
+        id: 'A',
+        rightNodeCount: 2,
+        data: { topic: { children: [{ text: 'A' }] } },
+        children: [
+            {
+                id: 'B',
+                type: 'mind_child',
+                data: { topic: { children: [{ text: 'B' }] } },
+                children: [
+                    {
+                        id: 'C',
+                        type: 'mind_child',
+                        data: { topic: { children: [{ text: 'C' }] } },
+                        children: [{ id: 'D', type: 'mind_child', data: { topic: { children: [{ text: 'D' }] } }, children: [] }]
+                    }
+                ]
+            },
+            {
+                id: 'E',
+                type: 'mind_child',
+                data: { topic: { children: [{ text: 'E' }] } },
+                children: [
+                    {
+                        id: 'F',
+                        type: 'mind_child',
+                        data: { topic: { children: [{ text: 'F' }] } },
+                        children: [{ id: 'G', type: 'mind_child', data: { topic: { children: [{ text: 'G' }] } }, children: [] }]
+                    }
+                ]
+            }
+        ],
+        points: [[0, 0]],
+        isCollapsed: false
+    }
+];
 
 describe('with mind hotkey plugin', () => {
     let board: PlaitBoard;
+    let layoutRoot: MindNode | undefined;
     const targetPath = [0, 0];
     beforeEach(() => {
         const child1 = createMindElement('sub child', {});
@@ -35,6 +83,10 @@ describe('with mind hotkey plugin', () => {
     afterEach(() => {
         clearSelectedElement(board);
         clearNodeWeakMap(board);
+        if (layoutRoot) {
+            clearLayoutNodeWeakMap(layoutRoot);
+            layoutRoot = undefined;
+        }
     });
 
     it('collapse/expand node', () => {
@@ -130,5 +182,37 @@ describe('with mind hotkey plugin', () => {
             parent = PlaitNode.get<MindElement>(board, parentPath);
             expect(parent.children.length).toEqual(childrenCount);
         });
+    });
+
+    it('navigate selected mind node by arrow keys', () => {
+        const children = createNavigationTestingChildren();
+        board = createTestingBoard([withMindHotkey], children);
+        fakeNodeWeakMap(board);
+        layoutRoot = fakeMindLayout(board as PlaitBoard & PlaitMindBoard, PlaitNode.get<PlaitMind>(board, [0]));
+
+        const nodeB = PlaitNode.get<MindElement>(board, [0, 0]);
+        const nodeC = PlaitNode.get<MindElement>(board, [0, 0, 0]);
+        const nodeD = PlaitNode.get<MindElement>(board, [0, 0, 0, 0]);
+        const nodeF = PlaitNode.get<MindElement>(board, [0, 1, 0]);
+
+        clearSelectedElement(board);
+        addSelectedElement(board, nodeC);
+        board.keyDown(createKeyboardEvent('keydown', LEFT_ARROW, 'ArrowLeft', {}));
+        expect(getSelectedElements(board)[0]).toBe(nodeB);
+
+        clearSelectedElement(board);
+        addSelectedElement(board, nodeC);
+        board.keyDown(createKeyboardEvent('keydown', RIGHT_ARROW, 'ArrowRight', {}));
+        expect(getSelectedElements(board)[0]).toBe(nodeD);
+
+        clearSelectedElement(board);
+        addSelectedElement(board, nodeC);
+        board.keyDown(createKeyboardEvent('keydown', DOWN_ARROW, 'ArrowDown', {}));
+        expect(getSelectedElements(board)[0]).toBe(nodeF);
+
+        clearSelectedElement(board);
+        addSelectedElement(board, nodeF);
+        board.keyDown(createKeyboardEvent('keydown', UP_ARROW, 'ArrowUp', {}));
+        expect(getSelectedElements(board)[0]).toBe(nodeC);
     });
 });

--- a/packages/mind/src/plugins/with-mind-hotkey.spec.ts
+++ b/packages/mind/src/plugins/with-mind-hotkey.spec.ts
@@ -313,13 +313,173 @@ describe('with mind hotkey plugin', () => {
         expect(getSelectedElements(board)[0]).toBe(nodeD);
     }));
 
-    it('navigates visible siblings in indented layout', fakeAsync(() => {
-        createNavigationBoard(createNavigationTestingChildren(MindLayoutType.rightBottomIndented));
+    it('navigates standard split siblings within the same side', fakeAsync(() => {
+        const children = createNavigationTestingChildren();
+        children[0].rightNodeCount = 2;
+        children[0].children.push(
+            {
+                id: 'H',
+                type: 'mind_child',
+                data: { topic: { children: [{ text: 'H' }] } },
+                children: []
+            },
+            {
+                id: 'I',
+                type: 'mind_child',
+                data: { topic: { children: [{ text: 'I' }] } },
+                children: []
+            }
+        );
+        createNavigationBoard(children);
         const nodeB = PlaitNode.get<MindElement>(board, [0, 0]);
         const nodeE = PlaitNode.get<MindElement>(board, [0, 1]);
+        const nodeH = PlaitNode.get<MindElement>(board, [0, 2]);
+        const nodeI = PlaitNode.get<MindElement>(board, [0, 3]);
 
         navigateFrom(nodeB, DOWN_ARROW, 'ArrowDown');
-
         expect(getSelectedElements(board)[0]).toBe(nodeE);
+
+        navigateFrom(nodeE, DOWN_ARROW, 'ArrowDown');
+        expect(getSelectedElements(board)[0]).toBe(nodeE);
+
+        navigateFrom(nodeH, UP_ARROW, 'ArrowUp');
+        expect(getSelectedElements(board)[0]).toBe(nodeH);
+
+        navigateFrom(nodeH, DOWN_ARROW, 'ArrowDown');
+        expect(getSelectedElements(board)[0]).toBe(nodeI);
+
+        navigateFrom(nodeI, UP_ARROW, 'ArrowUp');
+        expect(getSelectedElements(board)[0]).toBe(nodeH);
+
+        navigateFrom(nodeH, UP_ARROW, 'ArrowUp');
+        expect(getSelectedElements(board)[0]).toBe(nodeH);
+
+        navigateFrom(nodeE, UP_ARROW, 'ArrowUp');
+        expect(getSelectedElements(board)[0]).toBe(nodeB);
+
+        navigateFrom(nodeB, DOWN_ARROW, 'ArrowDown');
+        expect(getSelectedElements(board)[0]).toBe(nodeE);
+    }));
+
+    it('navigates parent, child and siblings by upward layout direction', fakeAsync(() => {
+        const root = createNavigationBoard(createNavigationTestingChildren(MindLayoutType.upward));
+        const nodeB = PlaitNode.get<MindElement>(board, [0, 0]);
+        const nodeE = PlaitNode.get<MindElement>(board, [0, 1]);
+        const nodeF = PlaitNode.get<MindElement>(board, [0, 1, 0]);
+
+        navigateFrom(nodeE, UP_ARROW, 'ArrowUp');
+        expect(getSelectedElements(board)[0]).toBe(nodeF);
+
+        navigateFrom(nodeE, DOWN_ARROW, 'ArrowDown');
+        expect(getSelectedElements(board)[0]).toBe(root);
+
+        navigateFrom(nodeE, LEFT_ARROW, 'ArrowLeft');
+        expect(getSelectedElements(board)[0]).toBe(nodeB);
+
+        navigateFrom(nodeB, RIGHT_ARROW, 'ArrowRight');
+        expect(getSelectedElements(board)[0]).toBe(nodeE);
+    }));
+
+    it('navigates parent, child and siblings by indented layout direction', fakeAsync(() => {
+        const root = createNavigationBoard(createNavigationTestingChildren(MindLayoutType.rightBottomIndented));
+        const nodeB = PlaitNode.get<MindElement>(board, [0, 0]);
+        const nodeC = PlaitNode.get<MindElement>(board, [0, 0, 0]);
+        const nodeE = PlaitNode.get<MindElement>(board, [0, 1]);
+
+        navigateFrom(root, DOWN_ARROW, 'ArrowDown');
+        expect(getSelectedElements(board)[0]).toBe(nodeB);
+
+        navigateFrom(nodeB, UP_ARROW, 'ArrowUp');
+        expect(getSelectedElements(board)[0]).toBe(root);
+
+        navigateFrom(root, DOWN_ARROW, 'ArrowDown');
+        expect(getSelectedElements(board)[0]).toBe(nodeB);
+
+        navigateFrom(nodeB, RIGHT_ARROW, 'ArrowRight');
+        expect(getSelectedElements(board)[0]).toBe(nodeC);
+
+        navigateFrom(nodeC, LEFT_ARROW, 'ArrowLeft');
+        expect(getSelectedElements(board)[0]).toBe(nodeB);
+
+        navigateFrom(nodeB, DOWN_ARROW, 'ArrowDown');
+        expect(getSelectedElements(board)[0]).toBe(nodeE);
+
+        navigateFrom(nodeE, UP_ARROW, 'ArrowUp');
+        expect(getSelectedElements(board)[0]).toBe(nodeB);
+    }));
+
+    it('navigates parent, child and siblings by top indented layout direction', fakeAsync(() => {
+        const root = createNavigationBoard(createNavigationTestingChildren(MindLayoutType.rightTopIndented));
+        const nodeB = PlaitNode.get<MindElement>(board, [0, 0]);
+        const nodeC = PlaitNode.get<MindElement>(board, [0, 0, 0]);
+        const nodeE = PlaitNode.get<MindElement>(board, [0, 1]);
+        const nodeF = PlaitNode.get<MindElement>(board, [0, 1, 0]);
+
+        navigateFrom(root, UP_ARROW, 'ArrowUp');
+        expect(getSelectedElements(board)[0]).toBe(nodeB);
+
+        navigateFrom(nodeB, UP_ARROW, 'ArrowUp');
+        expect(getSelectedElements(board)[0]).toBe(nodeE);
+
+        navigateFrom(nodeE, DOWN_ARROW, 'ArrowDown');
+        expect(getSelectedElements(board)[0]).toBe(nodeB);
+
+        navigateFrom(nodeB, LEFT_ARROW, 'ArrowLeft');
+        expect(getSelectedElements(board)[0]).toBe(nodeB);
+
+        navigateFrom(nodeB, DOWN_ARROW, 'ArrowDown');
+        expect(getSelectedElements(board)[0]).toBe(root);
+
+        navigateFrom(root, UP_ARROW, 'ArrowUp');
+        expect(getSelectedElements(board)[0]).toBe(nodeB);
+
+        navigateFrom(nodeB, RIGHT_ARROW, 'ArrowRight');
+        expect(getSelectedElements(board)[0]).toBe(nodeC);
+
+        navigateFrom(nodeC, LEFT_ARROW, 'ArrowLeft');
+        expect(getSelectedElements(board)[0]).toBe(nodeB);
+
+        navigateFrom(nodeE, RIGHT_ARROW, 'ArrowRight');
+        expect(getSelectedElements(board)[0]).toBe(nodeF);
+
+        navigateFrom(nodeF, LEFT_ARROW, 'ArrowLeft');
+        expect(getSelectedElements(board)[0]).toBe(nodeE);
+    }));
+
+    it('does not navigate by geometry across indented hierarchy boundaries', fakeAsync(() => {
+        const children = createNavigationTestingChildren(MindLayoutType.rightTopIndented);
+        children[0].children[0].children.push({
+            id: 'H',
+            type: 'mind_child',
+            data: { topic: { children: [{ text: 'H' }] } },
+            children: []
+        });
+        children[0].children[0].children[0].children.push({
+            id: 'I',
+            type: 'mind_child',
+            data: { topic: { children: [{ text: 'I' }] } },
+            children: []
+        });
+        createNavigationBoard(children);
+        const nodeB = PlaitNode.get<MindElement>(board, [0, 0]);
+        const nodeC = PlaitNode.get<MindElement>(board, [0, 0, 0]);
+        const nodeD = PlaitNode.get<MindElement>(board, [0, 0, 0, 0]);
+        const nodeH = PlaitNode.get<MindElement>(board, [0, 0, 1]);
+        const nodeI = PlaitNode.get<MindElement>(board, [0, 0, 0, 1]);
+
+        navigateFrom(nodeI, UP_ARROW, 'ArrowUp');
+        expect(getSelectedElements(board)[0]).toBe(nodeI);
+
+        navigateFrom(nodeI, DOWN_ARROW, 'ArrowDown');
+        expect(getSelectedElements(board)[0]).toBe(nodeD);
+
+        navigateFrom(nodeH, UP_ARROW, 'ArrowUp');
+        expect(getSelectedElements(board)[0]).toBe(nodeH);
+
+        navigateFrom(nodeH, DOWN_ARROW, 'ArrowDown');
+        expect(getSelectedElements(board)[0]).toBe(nodeC);
+
+        navigateFrom(nodeC, LEFT_ARROW, 'ArrowLeft');
+        expect(getSelectedElements(board)[0]).toBe(nodeB);
     }));
 });

--- a/packages/mind/src/plugins/with-mind-hotkey.spec.ts
+++ b/packages/mind/src/plugins/with-mind-hotkey.spec.ts
@@ -30,9 +30,10 @@ import { PlaitMindBoard } from './with-mind.board';
 import { createMindElement } from '../utils';
 import { MindElement, PlaitMind } from '@plait/mind';
 import { fakeMindLayout, clearLayoutNodeWeakMap } from '../testing/core/fake-layout-node';
-import { MindNode } from '../interfaces';
+import { LayoutDirection, MindNode } from '../interfaces';
 import { withMind } from './with-mind';
 import { MindLayoutType } from '@plait/layouts';
+import { resolveLayoutRelationDirection } from '../utils/position/layout-direction';
 
 const createNavigationTestingChildren = (layout?: MindLayoutType): MindElement[] => [
     {
@@ -73,6 +74,25 @@ const createNavigationTestingChildren = (layout?: MindLayoutType): MindElement[]
         isCollapsed: false
     }
 ];
+
+const createNestedNavigationTestingChildren = (outerLayout = MindLayoutType.rightTopIndented, nestedLayout = MindLayoutType.right) => {
+    const children = createNavigationTestingChildren(outerLayout);
+    const nestedLayoutRoot = children[0].children[0];
+    nestedLayoutRoot.layout = nestedLayout;
+    nestedLayoutRoot.children.push({
+        id: 'H',
+        type: 'mind_child',
+        data: { topic: { children: [{ text: 'H' }] } },
+        children: []
+    });
+    nestedLayoutRoot.children.push({
+        id: 'I',
+        type: 'mind_child',
+        data: { topic: { children: [{ text: 'I' }] } },
+        children: []
+    });
+    return children;
+};
 
 describe('with mind hotkey plugin', () => {
     let board: PlaitBoard;
@@ -262,7 +282,7 @@ describe('with mind hotkey plugin', () => {
         expect(getSelectedElements(board)[0]).toBe(root);
     }));
 
-    it('prefers parent over previous sibling for horizontal structure navigation', fakeAsync(() => {
+    it('uses the parent relation for horizontal structure navigation', fakeAsync(() => {
         const root = createNavigationBoard();
         const nodeB = PlaitNode.get<MindElement>(board, [0, 0]);
         const nodeE = PlaitNode.get<MindElement>(board, [0, 1]);
@@ -313,7 +333,7 @@ describe('with mind hotkey plugin', () => {
         expect(getSelectedElements(board)[0]).toBe(nodeD);
     }));
 
-    it('navigates standard split siblings within the same side', fakeAsync(() => {
+    it('navigates standard siblings across the right and left branch boundary', fakeAsync(() => {
         const children = createNavigationTestingChildren();
         children[0].rightNodeCount = 2;
         children[0].children.push(
@@ -340,10 +360,10 @@ describe('with mind hotkey plugin', () => {
         expect(getSelectedElements(board)[0]).toBe(nodeE);
 
         navigateFrom(nodeE, DOWN_ARROW, 'ArrowDown');
-        expect(getSelectedElements(board)[0]).toBe(nodeE);
+        expect(getSelectedElements(board)[0]).toBe(nodeH);
 
         navigateFrom(nodeH, UP_ARROW, 'ArrowUp');
-        expect(getSelectedElements(board)[0]).toBe(nodeH);
+        expect(getSelectedElements(board)[0]).toBe(nodeE);
 
         navigateFrom(nodeH, DOWN_ARROW, 'ArrowDown');
         expect(getSelectedElements(board)[0]).toBe(nodeI);
@@ -351,14 +371,8 @@ describe('with mind hotkey plugin', () => {
         navigateFrom(nodeI, UP_ARROW, 'ArrowUp');
         expect(getSelectedElements(board)[0]).toBe(nodeH);
 
-        navigateFrom(nodeH, UP_ARROW, 'ArrowUp');
-        expect(getSelectedElements(board)[0]).toBe(nodeH);
-
         navigateFrom(nodeE, UP_ARROW, 'ArrowUp');
         expect(getSelectedElements(board)[0]).toBe(nodeB);
-
-        navigateFrom(nodeB, DOWN_ARROW, 'ArrowDown');
-        expect(getSelectedElements(board)[0]).toBe(nodeE);
     }));
 
     it('navigates parent, child and siblings by upward layout direction', fakeAsync(() => {
@@ -444,6 +458,139 @@ describe('with mind hotkey plugin', () => {
 
         navigateFrom(nodeF, LEFT_ARROW, 'ArrowLeft');
         expect(getSelectedElements(board)[0]).toBe(nodeE);
+    }));
+
+    it('uses the outer parent-child context for a nested layout root', fakeAsync(() => {
+        const root = createNavigationBoard(createNestedNavigationTestingChildren());
+        const nestedLayoutRoot = PlaitNode.get<MindElement>(board, [0, 0]);
+
+        navigateFrom(root, UP_ARROW, 'ArrowUp');
+        expect(getSelectedElements(board)[0]).toBe(nestedLayoutRoot);
+
+        navigateFrom(nestedLayoutRoot, DOWN_ARROW, 'ArrowDown');
+        expect(getSelectedElements(board)[0]).toBe(root);
+    }));
+
+    it('resolves nested relationship directions from each layout owner', () => {
+        const root = createNavigationBoard(createNestedNavigationTestingChildren());
+        const nestedLayoutRoot = PlaitNode.get<MindElement>(board, [0, 0]);
+        const nestedChild = PlaitNode.get<MindElement>(board, [0, 0, 0]);
+
+        expect(
+            resolveLayoutRelationDirection(board, {
+                type: 'parent-child',
+                parent: root,
+                child: nestedLayoutRoot
+            })
+        ).toBe(LayoutDirection.top);
+        expect(
+            resolveLayoutRelationDirection(board, {
+                type: 'sibling',
+                parent: root,
+                order: 'next'
+            })
+        ).toBe(LayoutDirection.top);
+        expect(
+            resolveLayoutRelationDirection(board, {
+                type: 'sibling',
+                parent: root,
+                order: 'previous'
+            })
+        ).toBe(LayoutDirection.bottom);
+        expect(
+            resolveLayoutRelationDirection(board, {
+                type: 'parent-child',
+                parent: nestedLayoutRoot,
+                child: nestedChild
+            })
+        ).toBe(LayoutDirection.right);
+        expect(
+            resolveLayoutRelationDirection(board, {
+                type: 'sibling',
+                parent: nestedLayoutRoot,
+                order: 'next'
+            })
+        ).toBe(LayoutDirection.top);
+        expect(
+            resolveLayoutRelationDirection(board, {
+                type: 'sibling',
+                parent: nestedLayoutRoot,
+                order: 'previous'
+            })
+        ).toBe(LayoutDirection.bottom);
+    });
+
+    it('uses the outer sibling context at a nested layout boundary', fakeAsync(() => {
+        createNavigationBoard(createNestedNavigationTestingChildren());
+        const nestedLayoutRoot = PlaitNode.get<MindElement>(board, [0, 0]);
+        const nextOuterSibling = PlaitNode.get<MindElement>(board, [0, 1]);
+
+        navigateFrom(nestedLayoutRoot, UP_ARROW, 'ArrowUp');
+        expect(getSelectedElements(board)[0]).toBe(nextOuterSibling);
+
+        navigateFrom(nextOuterSibling, DOWN_ARROW, 'ArrowDown');
+        expect(getSelectedElements(board)[0]).toBe(nestedLayoutRoot);
+    }));
+
+    it('uses the nested layout context for descendant navigation', fakeAsync(() => {
+        createNavigationBoard(createNestedNavigationTestingChildren());
+        const nestedLayoutRoot = PlaitNode.get<MindElement>(board, [0, 0]);
+        const firstChild = PlaitNode.get<MindElement>(board, [0, 0, 0]);
+        const firstGrandchild = PlaitNode.get<MindElement>(board, [0, 0, 0, 0]);
+        const secondChild = PlaitNode.get<MindElement>(board, [0, 0, 1]);
+        const thirdChild = PlaitNode.get<MindElement>(board, [0, 0, 2]);
+
+        navigateFrom(nestedLayoutRoot, RIGHT_ARROW, 'ArrowRight');
+        expect(getSelectedElements(board)[0]).toBe(firstChild);
+
+        navigateFrom(firstChild, RIGHT_ARROW, 'ArrowRight');
+        expect(getSelectedElements(board)[0]).toBe(firstGrandchild);
+
+        navigateFrom(firstGrandchild, LEFT_ARROW, 'ArrowLeft');
+        expect(getSelectedElements(board)[0]).toBe(firstChild);
+
+        navigateFrom(firstChild, UP_ARROW, 'ArrowUp');
+        expect(getSelectedElements(board)[0]).toBe(secondChild);
+
+        navigateFrom(secondChild, UP_ARROW, 'ArrowUp');
+        expect(getSelectedElements(board)[0]).toBe(thirdChild);
+
+        navigateFrom(thirdChild, DOWN_ARROW, 'ArrowDown');
+        expect(getSelectedElements(board)[0]).toBe(secondChild);
+
+        navigateFrom(secondChild, DOWN_ARROW, 'ArrowDown');
+        expect(getSelectedElements(board)[0]).toBe(firstChild);
+
+        navigateFrom(firstChild, LEFT_ARROW, 'ArrowLeft');
+        expect(getSelectedElements(board)[0]).toBe(nestedLayoutRoot);
+    }));
+
+    it('uses the rendered horizontal mirror for vertical-layout siblings', fakeAsync(() => {
+        createNavigationBoard(createNestedNavigationTestingChildren(MindLayoutType.left, MindLayoutType.downward));
+        const nestedLayoutRoot = PlaitNode.get<MindElement>(board, [0, 0]);
+        const firstChild = PlaitNode.get<MindElement>(board, [0, 0, 0]);
+        const secondChild = PlaitNode.get<MindElement>(board, [0, 0, 1]);
+        const thirdChild = PlaitNode.get<MindElement>(board, [0, 0, 2]);
+
+        expect(
+            resolveLayoutRelationDirection(board, {
+                type: 'sibling',
+                parent: nestedLayoutRoot,
+                order: 'next'
+            })
+        ).toBe(LayoutDirection.left);
+
+        navigateFrom(firstChild, LEFT_ARROW, 'ArrowLeft');
+        expect(getSelectedElements(board)[0]).toBe(secondChild);
+
+        navigateFrom(secondChild, LEFT_ARROW, 'ArrowLeft');
+        expect(getSelectedElements(board)[0]).toBe(thirdChild);
+
+        navigateFrom(thirdChild, RIGHT_ARROW, 'ArrowRight');
+        expect(getSelectedElements(board)[0]).toBe(secondChild);
+
+        navigateFrom(secondChild, RIGHT_ARROW, 'ArrowRight');
+        expect(getSelectedElements(board)[0]).toBe(firstChild);
     }));
 
     it('does not navigate by geometry across indented hierarchy boundaries', fakeAsync(() => {

--- a/packages/mind/src/plugins/with-mind-hotkey.spec.ts
+++ b/packages/mind/src/plugins/with-mind-hotkey.spec.ts
@@ -2,8 +2,10 @@ import {
     DOWN_ARROW,
     ENTER,
     LEFT_ARROW,
+    NODE_TO_CONTAINER_G,
     Path,
     PlaitBoard,
+    PlaitElement,
     PlaitNode,
     RIGHT_ARROW,
     SLASH,
@@ -15,9 +17,13 @@ import {
     createKeyboardEvent,
     createModModifierKeys,
     createTestingBoard,
+    depthFirstRecursion,
     fakeNodeWeakMap,
-    getSelectedElements
+    getSelectedElements,
+    withOptions,
+    withSelection
 } from '@plait/core';
+import { fakeAsync, tick } from '@angular/core/testing';
 import { getTestingChildren } from '../testing/data/basic';
 import { withMindHotkey } from './with-mind-hotkey';
 import { PlaitMindBoard } from './with-mind.board';
@@ -25,12 +31,15 @@ import { createMindElement } from '../utils';
 import { MindElement, PlaitMind } from '@plait/mind';
 import { fakeMindLayout, clearLayoutNodeWeakMap } from '../testing/core/fake-layout-node';
 import { MindNode } from '../interfaces';
+import { withMind } from './with-mind';
+import { MindLayoutType } from '@plait/layouts';
 
-const createNavigationTestingChildren = (): MindElement[] => [
+const createNavigationTestingChildren = (layout?: MindLayoutType): MindElement[] => [
     {
         type: 'mind',
         id: 'A',
         rightNodeCount: 2,
+        layout,
         data: { topic: { children: [{ text: 'A' }] } },
         children: [
             {
@@ -68,7 +77,33 @@ const createNavigationTestingChildren = (): MindElement[] => [
 describe('with mind hotkey plugin', () => {
     let board: PlaitBoard;
     let layoutRoot: MindNode | undefined;
+    let mountedElements: PlaitElement[] = [];
     const targetPath = [0, 0];
+    const fakeMountedElements = (root: MindElement) => {
+        depthFirstRecursion<MindElement>(root, (node) => {
+            NODE_TO_CONTAINER_G.set(node, document.createElementNS('http://www.w3.org/2000/svg', 'g'));
+            mountedElements.push(node);
+        });
+    };
+    const createNavigationBoard = (children = createNavigationTestingChildren()) => {
+        clearSelectedElement(board);
+        clearNodeWeakMap(board);
+        board = createTestingBoard([withOptions, withSelection, withMind], children);
+        fakeNodeWeakMap(board);
+        const root = PlaitNode.get<PlaitMind>(board, [0]);
+        layoutRoot = fakeMindLayout(board as PlaitBoard & PlaitMindBoard, root);
+        fakeMountedElements(root);
+        return root;
+    };
+    const navigateFrom = (element: MindElement, keyCode: number, key: string) => {
+        clearSelectedElement(board);
+        addSelectedElement(board, element);
+        const event = createKeyboardEvent('keydown', keyCode, key, {});
+        board.keyDown(event);
+        tick(200);
+        return event;
+    };
+
     beforeEach(() => {
         const child1 = createMindElement('sub child', {});
         const children = getTestingChildren();
@@ -87,6 +122,8 @@ describe('with mind hotkey plugin', () => {
             clearLayoutNodeWeakMap(layoutRoot);
             layoutRoot = undefined;
         }
+        mountedElements.forEach((element) => NODE_TO_CONTAINER_G.delete(element));
+        mountedElements = [];
     });
 
     it('collapse/expand node', () => {
@@ -184,35 +221,68 @@ describe('with mind hotkey plugin', () => {
         });
     });
 
-    it('navigate selected mind node by arrow keys', () => {
-        const children = createNavigationTestingChildren();
-        board = createTestingBoard([withMindHotkey], children);
-        fakeNodeWeakMap(board);
-        layoutRoot = fakeMindLayout(board as PlaitBoard & PlaitMindBoard, PlaitNode.get<PlaitMind>(board, [0]));
+    it('navigate selected mind node by arrow keys', fakeAsync(() => {
+        createNavigationBoard();
 
         const nodeB = PlaitNode.get<MindElement>(board, [0, 0]);
         const nodeC = PlaitNode.get<MindElement>(board, [0, 0, 0]);
         const nodeD = PlaitNode.get<MindElement>(board, [0, 0, 0, 0]);
         const nodeF = PlaitNode.get<MindElement>(board, [0, 1, 0]);
 
-        clearSelectedElement(board);
-        addSelectedElement(board, nodeC);
-        board.keyDown(createKeyboardEvent('keydown', LEFT_ARROW, 'ArrowLeft', {}));
+        navigateFrom(nodeC, LEFT_ARROW, 'ArrowLeft');
         expect(getSelectedElements(board)[0]).toBe(nodeB);
 
-        clearSelectedElement(board);
-        addSelectedElement(board, nodeC);
-        board.keyDown(createKeyboardEvent('keydown', RIGHT_ARROW, 'ArrowRight', {}));
+        navigateFrom(nodeC, RIGHT_ARROW, 'ArrowRight');
         expect(getSelectedElements(board)[0]).toBe(nodeD);
 
-        clearSelectedElement(board);
-        addSelectedElement(board, nodeC);
-        board.keyDown(createKeyboardEvent('keydown', DOWN_ARROW, 'ArrowDown', {}));
+        navigateFrom(nodeC, DOWN_ARROW, 'ArrowDown');
         expect(getSelectedElements(board)[0]).toBe(nodeF);
 
-        clearSelectedElement(board);
-        addSelectedElement(board, nodeF);
-        board.keyDown(createKeyboardEvent('keydown', UP_ARROW, 'ArrowUp', {}));
+        navigateFrom(nodeF, UP_ARROW, 'ArrowUp');
         expect(getSelectedElements(board)[0]).toBe(nodeC);
-    });
+    }));
+
+    it('does not handle arrow navigation when the root mind is selected', fakeAsync(() => {
+        const root = createNavigationBoard();
+
+        const event = navigateFrom(root, RIGHT_ARROW, 'ArrowRight');
+
+        expect(event.defaultPrevented).toBe(false);
+        expect(getSelectedElements(board)[0]).toBe(root);
+    }));
+
+    it('does not navigate into hidden descendants of a collapsed node', fakeAsync(() => {
+        const children = createNavigationTestingChildren();
+        children[0].children[0].children[0].isCollapsed = true;
+        createNavigationBoard(children);
+        const nodeC = PlaitNode.get<MindElement>(board, [0, 0, 0]);
+        const nodeD = PlaitNode.get<MindElement>(board, [0, 0, 0, 0]);
+        const nodeG = PlaitNode.get<MindElement>(board, [0, 1, 0, 0]);
+
+        const event = navigateFrom(nodeC, RIGHT_ARROW, 'ArrowRight');
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(getSelectedElements(board)[0]).not.toBe(nodeD);
+        expect(getSelectedElements(board)[0]).toBe(nodeG);
+    }));
+
+    it('does not prevent default behavior when no navigation candidate exists', fakeAsync(() => {
+        createNavigationBoard();
+        const nodeD = PlaitNode.get<MindElement>(board, [0, 0, 0, 0]);
+
+        const event = navigateFrom(nodeD, RIGHT_ARROW, 'ArrowRight');
+
+        expect(event.defaultPrevented).toBe(false);
+        expect(getSelectedElements(board)[0]).toBe(nodeD);
+    }));
+
+    it('navigates by visual geometry in indented layout', fakeAsync(() => {
+        createNavigationBoard(createNavigationTestingChildren(MindLayoutType.rightBottomIndented));
+        const nodeB = PlaitNode.get<MindElement>(board, [0, 0]);
+        const nodeE = PlaitNode.get<MindElement>(board, [0, 1]);
+
+        navigateFrom(nodeB, DOWN_ARROW, 'ArrowDown');
+
+        expect(getSelectedElements(board)[0]).toBe(nodeE);
+    }));
 });

--- a/packages/mind/src/plugins/with-mind-hotkey.spec.ts
+++ b/packages/mind/src/plugins/with-mind-hotkey.spec.ts
@@ -27,7 +27,7 @@ import { fakeAsync, tick } from '@angular/core/testing';
 import { getTestingChildren } from '../testing/data/basic';
 import { withMindHotkey } from './with-mind-hotkey';
 import { PlaitMindBoard } from './with-mind.board';
-import { createMindElement } from '../utils';
+import { createMindElement, getRectangleByNode } from '../utils';
 import { MindElement, PlaitMind } from '@plait/mind';
 import { fakeMindLayout, clearLayoutNodeWeakMap } from '../testing/core/fake-layout-node';
 import { LayoutDirection, MindNode } from '../interfaces';
@@ -309,7 +309,7 @@ describe('with mind hotkey plugin', () => {
         expect(getSelectedElements(board)[0]).toBe(nodeE);
     }));
 
-    it('does not navigate into hidden descendants or distant geometry candidates', fakeAsync(() => {
+    it('does not navigate into hidden descendants or elements outside the navigation lane', fakeAsync(() => {
         const children = createNavigationTestingChildren();
         children[0].children[0].children[0].isCollapsed = true;
         createNavigationBoard(children);
@@ -321,6 +321,30 @@ describe('with mind hotkey plugin', () => {
         expect(event.defaultPrevented).toBe(true);
         expect(getSelectedElements(board)[0]).not.toBe(nodeD);
         expect(getSelectedElements(board)[0]).toBe(nodeC);
+    }));
+
+    it('keeps visible traversal order when geometry candidates have equal movement-axis distance', fakeAsync(() => {
+        createNavigationBoard();
+        const source = PlaitNode.get<MindElement>(board, [0, 0, 0, 0]);
+        const firstCandidate = PlaitNode.get<MindElement>(board, [0, 1, 0, 0]);
+        const secondCandidate = PlaitNode.get<MindElement>(board, [0, 1, 0]);
+        const sourceNode = MindElement.getNode(source);
+        const firstCandidateNode = MindElement.getNode(firstCandidate);
+        const secondCandidateNode = MindElement.getNode(secondCandidate);
+        const sourceRectangle = getRectangleByNode(sourceNode);
+        const firstCandidateRectangle = getRectangleByNode(firstCandidateNode);
+        const secondCandidateRectangle = getRectangleByNode(secondCandidateNode);
+        const targetCenterY = sourceRectangle.y + sourceRectangle.height / 2 + 100;
+
+        firstCandidateNode.x = sourceRectangle.x + sourceRectangle.width - 1 - firstCandidateNode.hGap;
+        firstCandidateNode.y = targetCenterY - firstCandidateRectangle.height / 2 - firstCandidateNode.vGap;
+        secondCandidateNode.x =
+            sourceRectangle.x + sourceRectangle.width / 2 - secondCandidateRectangle.width / 2 - secondCandidateNode.hGap;
+        secondCandidateNode.y = targetCenterY - secondCandidateRectangle.height / 2 - secondCandidateNode.vGap;
+
+        navigateFrom(source, DOWN_ARROW, 'ArrowDown');
+
+        expect(getSelectedElements(board)[0]).toBe(firstCandidate);
     }));
 
     it('prevents default behavior when no navigation candidate exists', fakeAsync(() => {
@@ -593,7 +617,7 @@ describe('with mind hotkey plugin', () => {
         expect(getSelectedElements(board)[0]).toBe(firstChild);
     }));
 
-    it('does not navigate by geometry across indented hierarchy boundaries', fakeAsync(() => {
+    it('uses geometry fallback across indented hierarchy boundaries', fakeAsync(() => {
         const children = createNavigationTestingChildren(MindLayoutType.rightTopIndented);
         children[0].children[0].children.push({
             id: 'H',
@@ -611,17 +635,19 @@ describe('with mind hotkey plugin', () => {
         const nodeB = PlaitNode.get<MindElement>(board, [0, 0]);
         const nodeC = PlaitNode.get<MindElement>(board, [0, 0, 0]);
         const nodeD = PlaitNode.get<MindElement>(board, [0, 0, 0, 0]);
+        const nodeF = PlaitNode.get<MindElement>(board, [0, 1, 0]);
+        const nodeG = PlaitNode.get<MindElement>(board, [0, 1, 0, 0]);
         const nodeH = PlaitNode.get<MindElement>(board, [0, 0, 1]);
         const nodeI = PlaitNode.get<MindElement>(board, [0, 0, 0, 1]);
 
         navigateFrom(nodeI, UP_ARROW, 'ArrowUp');
-        expect(getSelectedElements(board)[0]).toBe(nodeI);
+        expect(getSelectedElements(board)[0]).toBe(nodeG);
 
         navigateFrom(nodeI, DOWN_ARROW, 'ArrowDown');
         expect(getSelectedElements(board)[0]).toBe(nodeD);
 
         navigateFrom(nodeH, UP_ARROW, 'ArrowUp');
-        expect(getSelectedElements(board)[0]).toBe(nodeH);
+        expect(getSelectedElements(board)[0]).toBe(nodeF);
 
         navigateFrom(nodeH, DOWN_ARROW, 'ArrowDown');
         expect(getSelectedElements(board)[0]).toBe(nodeC);

--- a/packages/mind/src/plugins/with-mind-hotkey.spec.ts
+++ b/packages/mind/src/plugins/with-mind-hotkey.spec.ts
@@ -242,41 +242,78 @@ describe('with mind hotkey plugin', () => {
         expect(getSelectedElements(board)[0]).toBe(nodeC);
     }));
 
-    it('does not handle arrow navigation when the root mind is selected', fakeAsync(() => {
+    it('navigates from the selected root mind by arrow keys', fakeAsync(() => {
         const root = createNavigationBoard();
+        const nodeB = PlaitNode.get<MindElement>(board, [0, 0]);
 
-        const event = navigateFrom(root, RIGHT_ARROW, 'ArrowRight');
+        const rightEvent = navigateFrom(root, RIGHT_ARROW, 'ArrowRight');
 
-        expect(event.defaultPrevented).toBe(false);
+        expect(rightEvent.defaultPrevented).toBe(true);
+        expect(getSelectedElements(board)[0]).toBe(nodeB);
+
+        const leftEvent = navigateFrom(root, LEFT_ARROW, 'ArrowLeft');
+
+        expect(leftEvent.defaultPrevented).toBe(true);
+        expect(getSelectedElements(board)[0]).toBe(root);
+
+        const downEvent = navigateFrom(root, DOWN_ARROW, 'ArrowDown');
+
+        expect(downEvent.defaultPrevented).toBe(true);
         expect(getSelectedElements(board)[0]).toBe(root);
     }));
 
-    it('does not navigate into hidden descendants of a collapsed node', fakeAsync(() => {
+    it('prefers parent over previous sibling for horizontal structure navigation', fakeAsync(() => {
+        const root = createNavigationBoard();
+        const nodeB = PlaitNode.get<MindElement>(board, [0, 0]);
+        const nodeE = PlaitNode.get<MindElement>(board, [0, 1]);
+
+        const event = navigateFrom(nodeE, LEFT_ARROW, 'ArrowLeft');
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(getSelectedElements(board)[0]).not.toBe(nodeB);
+        expect(getSelectedElements(board)[0]).toBe(root);
+    }));
+
+    it('continues navigating from a root mind selected by arrow navigation', fakeAsync(() => {
+        const root = createNavigationBoard();
+        const nodeE = PlaitNode.get<MindElement>(board, [0, 1]);
+
+        navigateFrom(nodeE, LEFT_ARROW, 'ArrowLeft');
+        expect(getSelectedElements(board)[0]).toBe(root);
+
+        const event = createKeyboardEvent('keydown', RIGHT_ARROW, 'ArrowRight', {});
+        board.keyDown(event);
+        tick(200);
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(getSelectedElements(board)[0]).toBe(nodeE);
+    }));
+
+    it('does not navigate into hidden descendants or distant geometry candidates', fakeAsync(() => {
         const children = createNavigationTestingChildren();
         children[0].children[0].children[0].isCollapsed = true;
         createNavigationBoard(children);
         const nodeC = PlaitNode.get<MindElement>(board, [0, 0, 0]);
         const nodeD = PlaitNode.get<MindElement>(board, [0, 0, 0, 0]);
-        const nodeG = PlaitNode.get<MindElement>(board, [0, 1, 0, 0]);
 
         const event = navigateFrom(nodeC, RIGHT_ARROW, 'ArrowRight');
 
         expect(event.defaultPrevented).toBe(true);
         expect(getSelectedElements(board)[0]).not.toBe(nodeD);
-        expect(getSelectedElements(board)[0]).toBe(nodeG);
+        expect(getSelectedElements(board)[0]).toBe(nodeC);
     }));
 
-    it('does not prevent default behavior when no navigation candidate exists', fakeAsync(() => {
+    it('prevents default behavior when no navigation candidate exists', fakeAsync(() => {
         createNavigationBoard();
         const nodeD = PlaitNode.get<MindElement>(board, [0, 0, 0, 0]);
 
         const event = navigateFrom(nodeD, RIGHT_ARROW, 'ArrowRight');
 
-        expect(event.defaultPrevented).toBe(false);
+        expect(event.defaultPrevented).toBe(true);
         expect(getSelectedElements(board)[0]).toBe(nodeD);
     }));
 
-    it('navigates by visual geometry in indented layout', fakeAsync(() => {
+    it('navigates visible siblings in indented layout', fakeAsync(() => {
         createNavigationBoard(createNavigationTestingChildren(MindLayoutType.rightBottomIndented));
         const nodeB = PlaitNode.get<MindElement>(board, [0, 0]);
         const nodeE = PlaitNode.get<MindElement>(board, [0, 1]);

--- a/packages/mind/src/plugins/with-mind-hotkey.ts
+++ b/packages/mind/src/plugins/with-mind-hotkey.ts
@@ -1,4 +1,12 @@
-import { PlaitBoard, Transforms, getSelectedElements } from '@plait/core';
+import {
+    PlaitBoard,
+    RectangleClient,
+    Transforms,
+    cacheSelectedElements,
+    depthFirstRecursion,
+    getIsRecursionFunc,
+    getSelectedElements
+} from '@plait/core';
 import { MindElement, PlaitMind } from '../interfaces';
 import { AbstractNode } from '@plait/layouts';
 import { MindTransforms } from '../transforms';
@@ -6,6 +14,114 @@ import { editTopic } from '../utils/node/common';
 import { PlaitMindBoard } from './with-mind.board';
 import { isSpaceHotkey, isExpandHotkey, isTabHotkey, isEnterHotkey, isVirtualKey, isDelete, getFirstTextManage } from '@plait/common';
 import { isHotkey } from 'is-hotkey';
+import { getRectangleByNode } from '../utils/position/node';
+
+type NavigationDirection = 'left' | 'right' | 'up' | 'down';
+
+const getNavigationDirection = (event: KeyboardEvent): NavigationDirection | null => {
+    if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+        return null;
+    }
+    switch (event.key) {
+        case 'ArrowLeft':
+            return 'left';
+        case 'ArrowRight':
+            return 'right';
+        case 'ArrowUp':
+            return 'up';
+        case 'ArrowDown':
+            return 'down';
+        default:
+            return null;
+    }
+};
+
+const getElementCenter = (element: MindElement) => {
+    return RectangleClient.getCenterPoint(getRectangleByNode(MindElement.getNode(element)));
+};
+
+const isInNavigationDirection = (direction: NavigationDirection, source: MindElement, target: MindElement) => {
+    const sourceCenter = getElementCenter(source);
+    const targetCenter = getElementCenter(target);
+    if (direction === 'left') {
+        return targetCenter[0] < sourceCenter[0];
+    }
+    if (direction === 'right') {
+        return targetCenter[0] > sourceCenter[0];
+    }
+    if (direction === 'up') {
+        return targetCenter[1] < sourceCenter[1];
+    }
+    return targetCenter[1] > sourceCenter[1];
+};
+
+const hasCrossAxisOverlap = (direction: NavigationDirection, source: MindElement, target: MindElement) => {
+    const sourceRectangle = getRectangleByNode(MindElement.getNode(source));
+    const targetRectangle = getRectangleByNode(MindElement.getNode(target));
+    if (direction === 'left' || direction === 'right') {
+        return (
+            sourceRectangle.y <= targetRectangle.y + targetRectangle.height &&
+            targetRectangle.y <= sourceRectangle.y + sourceRectangle.height
+        );
+    }
+    return sourceRectangle.x <= targetRectangle.x + targetRectangle.width && targetRectangle.x <= sourceRectangle.x + sourceRectangle.width;
+};
+
+const getPrimaryDistance = (direction: NavigationDirection, source: MindElement, target: MindElement) => {
+    const sourceCenter = getElementCenter(source);
+    const targetCenter = getElementCenter(target);
+    if (direction === 'left' || direction === 'right') {
+        return Math.abs(targetCenter[0] - sourceCenter[0]);
+    }
+    return Math.abs(targetCenter[1] - sourceCenter[1]);
+};
+
+const getSecondaryDistance = (direction: NavigationDirection, source: MindElement, target: MindElement) => {
+    const sourceCenter = getElementCenter(source);
+    const targetCenter = getElementCenter(target);
+    if (direction === 'left' || direction === 'right') {
+        return Math.abs(targetCenter[1] - sourceCenter[1]);
+    }
+    return Math.abs(targetCenter[0] - sourceCenter[0]);
+};
+
+const getVisibleMindElements = (board: PlaitBoard, root: MindElement) => {
+    const elements: MindElement[] = [];
+    depthFirstRecursion<MindElement>(
+        root,
+        (node) => {
+            if (!AbstractNode.isAbstract(node)) {
+                elements.push(node);
+            }
+        },
+        getIsRecursionFunc(board)
+    );
+    return elements;
+};
+
+const getNextMindElementByDirection = (board: PlaitBoard, source: MindElement, direction: NavigationDirection) => {
+    const root = MindElement.getRoot(board, source);
+    return getVisibleMindElements(board, root)
+        .filter((element) => element !== source && isInNavigationDirection(direction, source, element))
+        .sort((a, b) => {
+            const overlapA = hasCrossAxisOverlap(direction, source, a);
+            const overlapB = hasCrossAxisOverlap(direction, source, b);
+            if (overlapA !== overlapB) {
+                return overlapA ? -1 : 1;
+            }
+            const primaryDistance = getPrimaryDistance(direction, source, a) - getPrimaryDistance(direction, source, b);
+            if (primaryDistance !== 0) {
+                return primaryDistance;
+            }
+            return getSecondaryDistance(direction, source, a) - getSecondaryDistance(direction, source, b);
+        })[0];
+};
+
+const selectMindElement = (board: PlaitBoard, element: MindElement) => {
+    cacheSelectedElements(board, [element]);
+    const center = getElementCenter(element);
+    Transforms.setSelection(board, { anchor: center, focus: center });
+};
 
 export const withMindHotkey = (baseBoard: PlaitBoard) => {
     const board = baseBoard as PlaitBoard & PlaitMindBoard;
@@ -24,6 +140,16 @@ export const withMindHotkey = (baseBoard: PlaitBoard) => {
                     { isCollapsed: targetElement.isCollapsed ? false : true },
                     PlaitBoard.findPath(board, targetElement)
                 );
+                return;
+            }
+        }
+
+        const navigationDirection = getNavigationDirection(event);
+        if (navigationDirection && isSingleMindElement && !PlaitBoard.hasBeenTextEditing(board)) {
+            const nextElement = getNextMindElementByDirection(board, targetElement, navigationDirection);
+            if (nextElement) {
+                event.preventDefault();
+                selectMindElement(board, nextElement);
                 return;
             }
         }

--- a/packages/mind/src/plugins/with-mind-hotkey.ts
+++ b/packages/mind/src/plugins/with-mind-hotkey.ts
@@ -8,6 +8,8 @@ import { isSpaceHotkey, isExpandHotkey, isTabHotkey, isEnterHotkey, isVirtualKey
 import { isHotkey } from 'is-hotkey';
 import { getMindElementCenter, getNextMindElementByDirection } from '../utils/position';
 
+const NAVIGATION_SELECTED_ELEMENT = new WeakMap<PlaitBoard, { selected: MindElement; previous?: MindElement }>();
+
 const getNavigationDirection = (event: KeyboardEvent): Direction | null => {
     if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
         return null;
@@ -26,20 +28,31 @@ const getNavigationDirection = (event: KeyboardEvent): Direction | null => {
     }
 };
 
-const selectMindElement = (board: PlaitBoard, element: MindElement) => {
+const selectMindElement = (board: PlaitBoard, element: MindElement, previous?: MindElement) => {
+    NAVIGATION_SELECTED_ELEMENT.set(board, { selected: element, previous });
     const center = getMindElementCenter(element);
     Transforms.setSelection(board, { anchor: center, focus: center });
 };
 
 export const withMindHotkey = (baseBoard: PlaitBoard) => {
     const board = baseBoard as PlaitBoard & PlaitMindBoard;
-    const { keyDown, globalKeyDown } = board;
+    const { keyDown, globalKeyDown, pointerDown } = board;
+
+    board.pointerDown = (event: PointerEvent) => {
+        NAVIGATION_SELECTED_ELEMENT.delete(board);
+        pointerDown(event);
+    };
 
     board.keyDown = (event: KeyboardEvent) => {
         const selectedElements = getSelectedElements(board);
         const isSingleSelection = selectedElements.length === 1;
         const isSingleMindElement = selectedElements.length === 1 && MindElement.isMindElement(board, selectedElements[0]);
         const targetElement = selectedElements[0] as MindElement;
+        let navigationSelectedElement = NAVIGATION_SELECTED_ELEMENT.get(board);
+        if (navigationSelectedElement && navigationSelectedElement.selected !== targetElement) {
+            NAVIGATION_SELECTED_ELEMENT.delete(board);
+            navigationSelectedElement = undefined;
+        }
 
         if (isExpandHotkey(event) && isSingleMindElement && !PlaitMind.isMind(targetElement)) {
             if (targetElement.children && targetElement.children.length > 0) {
@@ -53,13 +66,24 @@ export const withMindHotkey = (baseBoard: PlaitBoard) => {
         }
 
         const navigationDirection = getNavigationDirection(event);
-        if (navigationDirection && isSingleMindElement && !PlaitMind.isMind(targetElement) && !PlaitBoard.hasBeenTextEditing(board)) {
-            const nextElement = getNextMindElementByDirection(board, targetElement, navigationDirection);
+        if (
+            navigationDirection &&
+            isSingleMindElement &&
+            !PlaitBoard.hasBeenTextEditing(board)
+        ) {
+            const nextElement = getNextMindElementByDirection(
+                board,
+                targetElement,
+                navigationDirection,
+                navigationSelectedElement?.previous
+            );
             if (nextElement) {
                 event.preventDefault();
-                selectMindElement(board, nextElement);
+                selectMindElement(board, nextElement, targetElement);
                 return;
             }
+            event.preventDefault();
+            return;
         }
 
         if (!PlaitBoard.isReadonly(board)) {

--- a/packages/mind/src/plugins/with-mind-hotkey.ts
+++ b/packages/mind/src/plugins/with-mind-hotkey.ts
@@ -1,12 +1,4 @@
-import {
-    PlaitBoard,
-    RectangleClient,
-    Transforms,
-    cacheSelectedElements,
-    depthFirstRecursion,
-    getIsRecursionFunc,
-    getSelectedElements
-} from '@plait/core';
+import { Direction, PlaitBoard, Transforms, getSelectedElements } from '@plait/core';
 import { MindElement, PlaitMind } from '../interfaces';
 import { AbstractNode } from '@plait/layouts';
 import { MindTransforms } from '../transforms';
@@ -14,112 +6,28 @@ import { editTopic } from '../utils/node/common';
 import { PlaitMindBoard } from './with-mind.board';
 import { isSpaceHotkey, isExpandHotkey, isTabHotkey, isEnterHotkey, isVirtualKey, isDelete, getFirstTextManage } from '@plait/common';
 import { isHotkey } from 'is-hotkey';
-import { getRectangleByNode } from '../utils/position/node';
+import { getMindElementCenter, getNextMindElementByDirection } from '../utils/position';
 
-type NavigationDirection = 'left' | 'right' | 'up' | 'down';
-
-const getNavigationDirection = (event: KeyboardEvent): NavigationDirection | null => {
+const getNavigationDirection = (event: KeyboardEvent): Direction | null => {
     if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
         return null;
     }
     switch (event.key) {
         case 'ArrowLeft':
-            return 'left';
+            return Direction.left;
         case 'ArrowRight':
-            return 'right';
+            return Direction.right;
         case 'ArrowUp':
-            return 'up';
+            return Direction.top;
         case 'ArrowDown':
-            return 'down';
+            return Direction.bottom;
         default:
             return null;
     }
 };
 
-const getElementCenter = (element: MindElement) => {
-    return RectangleClient.getCenterPoint(getRectangleByNode(MindElement.getNode(element)));
-};
-
-const isInNavigationDirection = (direction: NavigationDirection, source: MindElement, target: MindElement) => {
-    const sourceCenter = getElementCenter(source);
-    const targetCenter = getElementCenter(target);
-    if (direction === 'left') {
-        return targetCenter[0] < sourceCenter[0];
-    }
-    if (direction === 'right') {
-        return targetCenter[0] > sourceCenter[0];
-    }
-    if (direction === 'up') {
-        return targetCenter[1] < sourceCenter[1];
-    }
-    return targetCenter[1] > sourceCenter[1];
-};
-
-const hasCrossAxisOverlap = (direction: NavigationDirection, source: MindElement, target: MindElement) => {
-    const sourceRectangle = getRectangleByNode(MindElement.getNode(source));
-    const targetRectangle = getRectangleByNode(MindElement.getNode(target));
-    if (direction === 'left' || direction === 'right') {
-        return (
-            sourceRectangle.y <= targetRectangle.y + targetRectangle.height &&
-            targetRectangle.y <= sourceRectangle.y + sourceRectangle.height
-        );
-    }
-    return sourceRectangle.x <= targetRectangle.x + targetRectangle.width && targetRectangle.x <= sourceRectangle.x + sourceRectangle.width;
-};
-
-const getPrimaryDistance = (direction: NavigationDirection, source: MindElement, target: MindElement) => {
-    const sourceCenter = getElementCenter(source);
-    const targetCenter = getElementCenter(target);
-    if (direction === 'left' || direction === 'right') {
-        return Math.abs(targetCenter[0] - sourceCenter[0]);
-    }
-    return Math.abs(targetCenter[1] - sourceCenter[1]);
-};
-
-const getSecondaryDistance = (direction: NavigationDirection, source: MindElement, target: MindElement) => {
-    const sourceCenter = getElementCenter(source);
-    const targetCenter = getElementCenter(target);
-    if (direction === 'left' || direction === 'right') {
-        return Math.abs(targetCenter[1] - sourceCenter[1]);
-    }
-    return Math.abs(targetCenter[0] - sourceCenter[0]);
-};
-
-const getVisibleMindElements = (board: PlaitBoard, root: MindElement) => {
-    const elements: MindElement[] = [];
-    depthFirstRecursion<MindElement>(
-        root,
-        (node) => {
-            if (!AbstractNode.isAbstract(node)) {
-                elements.push(node);
-            }
-        },
-        getIsRecursionFunc(board)
-    );
-    return elements;
-};
-
-const getNextMindElementByDirection = (board: PlaitBoard, source: MindElement, direction: NavigationDirection) => {
-    const root = MindElement.getRoot(board, source);
-    return getVisibleMindElements(board, root)
-        .filter((element) => element !== source && isInNavigationDirection(direction, source, element))
-        .sort((a, b) => {
-            const overlapA = hasCrossAxisOverlap(direction, source, a);
-            const overlapB = hasCrossAxisOverlap(direction, source, b);
-            if (overlapA !== overlapB) {
-                return overlapA ? -1 : 1;
-            }
-            const primaryDistance = getPrimaryDistance(direction, source, a) - getPrimaryDistance(direction, source, b);
-            if (primaryDistance !== 0) {
-                return primaryDistance;
-            }
-            return getSecondaryDistance(direction, source, a) - getSecondaryDistance(direction, source, b);
-        })[0];
-};
-
 const selectMindElement = (board: PlaitBoard, element: MindElement) => {
-    cacheSelectedElements(board, [element]);
-    const center = getElementCenter(element);
+    const center = getMindElementCenter(element);
     Transforms.setSelection(board, { anchor: center, focus: center });
 };
 
@@ -145,7 +53,7 @@ export const withMindHotkey = (baseBoard: PlaitBoard) => {
         }
 
         const navigationDirection = getNavigationDirection(event);
-        if (navigationDirection && isSingleMindElement && !PlaitBoard.hasBeenTextEditing(board)) {
+        if (navigationDirection && isSingleMindElement && !PlaitMind.isMind(targetElement) && !PlaitBoard.hasBeenTextEditing(board)) {
             const nextElement = getNextMindElementByDirection(board, targetElement, navigationDirection);
             if (nextElement) {
                 event.preventDefault();

--- a/packages/mind/src/utils/position/index.ts
+++ b/packages/mind/src/utils/position/index.ts
@@ -2,3 +2,4 @@ export * from './node';
 export * from './emoji';
 export * from './topic';
 export * from './image';
+export * from './navigation';

--- a/packages/mind/src/utils/position/layout-direction.ts
+++ b/packages/mind/src/utils/position/layout-direction.ts
@@ -1,0 +1,41 @@
+import { PlaitBoard } from '@plait/core';
+import { MindLayoutType, isHorizontalLayout, isIndentedLayout } from '@plait/layouts';
+import { LayoutDirection, MindElement, PlaitMind } from '../../interfaces';
+import { MindQueries } from '../../queries';
+import { getLayoutReverseDirection } from '../layout';
+import { getLayoutDirection as getNodeLayoutDirection } from '../point-placement';
+
+export type LayoutRelation =
+    | {
+          type: 'parent-child';
+          parent: MindElement;
+          child: MindElement;
+      }
+    | {
+          type: 'sibling';
+          parent: MindElement;
+          order: 'previous' | 'next';
+      };
+
+const isLayoutRoot = (element: MindElement) => {
+    return PlaitMind.isMind(element) || !!element.layout;
+};
+
+export const resolveLayoutRelationDirection = (board: PlaitBoard, relation: LayoutRelation): LayoutDirection => {
+    const layout = MindQueries.getCorrectLayoutByElement(board, relation.parent) as MindLayoutType;
+    const parentNode = MindElement.getNode(relation.parent);
+
+    if (relation.type === 'sibling') {
+        // Siblings follow the cross axis and keep the parent's final mirrored orientation.
+        const isSiblingHorizontal = !isHorizontalLayout(layout);
+        const nextDirection = getNodeLayoutDirection(parentNode, isSiblingHorizontal);
+
+        return relation.order === 'next' ? nextDirection : getLayoutReverseDirection(nextDirection);
+    }
+
+    if (isIndentedLayout(layout) && isLayoutRoot(relation.parent)) {
+        return getNodeLayoutDirection(parentNode, false);
+    }
+
+    return getNodeLayoutDirection(MindElement.getNode(relation.child), isHorizontalLayout(layout));
+};

--- a/packages/mind/src/utils/position/navigation.ts
+++ b/packages/mind/src/utils/position/navigation.ts
@@ -1,0 +1,82 @@
+import { Direction, PlaitBoard, RectangleClient, depthFirstRecursion, getIsRecursionFunc, isHorizontalDirection } from '@plait/core';
+import { AbstractNode } from '@plait/layouts';
+import { MindElement } from '../../interfaces';
+import { getRectangleByNode } from './node';
+
+export const getMindElementCenter = (element: MindElement) => {
+    return RectangleClient.getCenterPoint(getRectangleByNode(MindElement.getNode(element)));
+};
+
+const isInNavigationDirection = (direction: Direction, source: MindElement, target: MindElement) => {
+    const sourceCenter = getMindElementCenter(source);
+    const targetCenter = getMindElementCenter(target);
+    if (direction === Direction.left) {
+        return targetCenter[0] < sourceCenter[0];
+    }
+    if (direction === Direction.right) {
+        return targetCenter[0] > sourceCenter[0];
+    }
+    if (direction === Direction.top) {
+        return targetCenter[1] < sourceCenter[1];
+    }
+    return targetCenter[1] > sourceCenter[1];
+};
+
+const hasCrossAxisOverlap = (direction: Direction, source: MindElement, target: MindElement) => {
+    const sourceRectangle = getRectangleByNode(MindElement.getNode(source));
+    const targetRectangle = getRectangleByNode(MindElement.getNode(target));
+    if (isHorizontalDirection(direction)) {
+        return RectangleClient.isHitY(sourceRectangle, targetRectangle);
+    }
+    return RectangleClient.isHitX(sourceRectangle, targetRectangle);
+};
+
+const getPrimaryDistance = (direction: Direction, source: MindElement, target: MindElement) => {
+    const sourceCenter = getMindElementCenter(source);
+    const targetCenter = getMindElementCenter(target);
+    if (isHorizontalDirection(direction)) {
+        return Math.abs(targetCenter[0] - sourceCenter[0]);
+    }
+    return Math.abs(targetCenter[1] - sourceCenter[1]);
+};
+
+const getSecondaryDistance = (direction: Direction, source: MindElement, target: MindElement) => {
+    const sourceCenter = getMindElementCenter(source);
+    const targetCenter = getMindElementCenter(target);
+    if (isHorizontalDirection(direction)) {
+        return Math.abs(targetCenter[1] - sourceCenter[1]);
+    }
+    return Math.abs(targetCenter[0] - sourceCenter[0]);
+};
+
+const getVisibleMindElements = (board: PlaitBoard, root: MindElement) => {
+    const elements: MindElement[] = [];
+    depthFirstRecursion<MindElement>(
+        root,
+        (node) => {
+            if (!AbstractNode.isAbstract(node)) {
+                elements.push(node);
+            }
+        },
+        getIsRecursionFunc(board)
+    );
+    return elements;
+};
+
+export const getNextMindElementByDirection = (board: PlaitBoard, source: MindElement, direction: Direction) => {
+    const root = MindElement.getRoot(board, source);
+    return getVisibleMindElements(board, root)
+        .filter((element) => element !== source && isInNavigationDirection(direction, source, element))
+        .sort((a, b) => {
+            const overlapA = hasCrossAxisOverlap(direction, source, a);
+            const overlapB = hasCrossAxisOverlap(direction, source, b);
+            if (overlapA !== overlapB) {
+                return overlapA ? -1 : 1;
+            }
+            const primaryDistance = getPrimaryDistance(direction, source, a) - getPrimaryDistance(direction, source, b);
+            if (primaryDistance !== 0) {
+                return primaryDistance;
+            }
+            return getSecondaryDistance(direction, source, a) - getSecondaryDistance(direction, source, b);
+        })[0];
+};

--- a/packages/mind/src/utils/position/navigation.ts
+++ b/packages/mind/src/utils/position/navigation.ts
@@ -63,20 +63,101 @@ const getVisibleMindElements = (board: PlaitBoard, root: MindElement) => {
     return elements;
 };
 
-export const getNextMindElementByDirection = (board: PlaitBoard, source: MindElement, direction: Direction) => {
+const getVisibleChildren = (board: PlaitBoard, element: MindElement) => {
+    if (!getIsRecursionFunc(board)(element)) {
+        return [];
+    }
+    return element.children?.filter((child) => !AbstractNode.isAbstract(child)) || [];
+};
+
+const getVisibleParent = (element: MindElement) => {
+    let parent = MindElement.findParent(element);
+    while (parent && AbstractNode.isAbstract(parent)) {
+        parent = MindElement.findParent(parent);
+    }
+    return parent;
+};
+
+const isInHorizontalDirection = (source: MindElement, target: MindElement, direction: Direction) => {
+    const sourceCenter = getMindElementCenter(source);
+    const targetCenter = getMindElementCenter(target);
+    if (direction === Direction.left) {
+        return targetCenter[0] < sourceCenter[0];
+    }
+    if (direction === Direction.right) {
+        return targetCenter[0] > sourceCenter[0];
+    }
+    return false;
+};
+
+const getVisibleSiblingByDirection = (board: PlaitBoard, source: MindElement, direction: Direction) => {
+    const parent = getVisibleParent(source);
+    if (!parent) {
+        return undefined;
+    }
+    const siblings = getVisibleChildren(board, parent);
+    const sourceIndex = siblings.indexOf(source);
+    if (sourceIndex === -1) {
+        return undefined;
+    }
+    if (direction === Direction.top) {
+        return siblings[sourceIndex - 1];
+    }
+    if (direction === Direction.bottom) {
+        return siblings[sourceIndex + 1];
+    }
+    return undefined;
+};
+
+const getParentOrChildByHorizontalDirection = (
+    board: PlaitBoard,
+    source: MindElement,
+    direction: Direction,
+    previousElement?: MindElement
+) => {
+    const parent = getVisibleParent(source);
+    if (parent && isInHorizontalDirection(source, parent, direction)) {
+        return parent;
+    }
+    const children = getVisibleChildren(board, source);
+    if (previousElement && children.includes(previousElement) && isInHorizontalDirection(source, previousElement, direction)) {
+        return previousElement;
+    }
+    return children.find((child) => isInHorizontalDirection(source, child, direction));
+};
+
+const getNextMindElementByStructure = (board: PlaitBoard, source: MindElement, direction: Direction, previousElement?: MindElement) => {
+    if (direction === Direction.left || direction === Direction.right) {
+        return getParentOrChildByHorizontalDirection(board, source, direction, previousElement);
+    }
+    return getVisibleSiblingByDirection(board, source, direction);
+};
+
+const getNextMindElementByGeometry = (board: PlaitBoard, source: MindElement, direction: Direction) => {
     const root = MindElement.getRoot(board, source);
     return getVisibleMindElements(board, root)
-        .filter((element) => element !== source && isInNavigationDirection(direction, source, element))
+        .filter(
+            (element) =>
+                element !== source &&
+                isInNavigationDirection(direction, source, element) &&
+                hasCrossAxisOverlap(direction, source, element)
+        )
         .sort((a, b) => {
-            const overlapA = hasCrossAxisOverlap(direction, source, a);
-            const overlapB = hasCrossAxisOverlap(direction, source, b);
-            if (overlapA !== overlapB) {
-                return overlapA ? -1 : 1;
-            }
             const primaryDistance = getPrimaryDistance(direction, source, a) - getPrimaryDistance(direction, source, b);
             if (primaryDistance !== 0) {
                 return primaryDistance;
             }
             return getSecondaryDistance(direction, source, a) - getSecondaryDistance(direction, source, b);
         })[0];
+};
+
+export const getNextMindElementByDirection = (
+    board: PlaitBoard,
+    source: MindElement,
+    direction: Direction,
+    previousElement?: MindElement
+) => {
+    return (
+        getNextMindElementByStructure(board, source, direction, previousElement) || getNextMindElementByGeometry(board, source, direction)
+    );
 };

--- a/packages/mind/src/utils/position/navigation.ts
+++ b/packages/mind/src/utils/position/navigation.ts
@@ -1,17 +1,11 @@
 import { Direction, PlaitBoard, RectangleClient, depthFirstRecursion, getIsRecursionFunc, isHorizontalDirection } from '@plait/core';
-import { AbstractNode, MindLayoutType, isHorizontalLayout, isIndentedLayout, isRightLayout, isTopLayout } from '@plait/layouts';
-import { LayoutDirection, MindElement, PlaitMind } from '../../interfaces';
+import { AbstractNode, MindLayoutType, isHorizontalLayout, isIndentedLayout, isRightLayout } from '@plait/layouts';
+import { LayoutDirection, MindElement } from '../../interfaces';
 import { MindQueries } from '../../queries';
 import { getLayoutDirection as getNodeLayoutDirection } from '../point-placement';
 import { getLayoutReverseDirection } from '../layout';
+import { resolveLayoutRelationDirection } from './layout-direction';
 import { getRectangleByNode } from './node';
-
-const LayoutDirectionToDirection = {
-    [LayoutDirection.left]: Direction.left,
-    [LayoutDirection.right]: Direction.right,
-    [LayoutDirection.top]: Direction.top,
-    [LayoutDirection.bottom]: Direction.bottom
-};
 
 const DirectionToLayoutDirection = {
     [Direction.left]: LayoutDirection.left,
@@ -39,7 +33,7 @@ const isInNavigationDirection = (direction: Direction, source: MindElement, targ
     return targetCenter[1] > sourceCenter[1];
 };
 
-const hasCrossAxisOverlap = (direction: Direction, source: MindElement, target: MindElement) => {
+const isInSameNavigationLane = (direction: Direction, source: MindElement, target: MindElement) => {
     const sourceRectangle = getRectangleByNode(MindElement.getNode(source));
     const targetRectangle = getRectangleByNode(MindElement.getNode(target));
     if (isHorizontalDirection(direction)) {
@@ -109,93 +103,107 @@ const getCorrectLayout = (board: PlaitBoard, element: MindElement) => {
     return MindQueries.getCorrectLayoutByElement(board, element) as MindLayoutType;
 };
 
-const getIndentedHierarchyLayoutDirection = (layout: MindLayoutType) => {
-    return isRightLayout(layout) ? LayoutDirection.right : LayoutDirection.left;
-};
-
-const getIndentedBranchLayoutDirection = (layout: MindLayoutType) => {
-    return isTopLayout(layout) ? LayoutDirection.top : LayoutDirection.bottom;
-};
-
-const getParentChildLayoutDirection = (board: PlaitBoard, element: MindElement) => {
+const getGeometryLayoutDirection = (board: PlaitBoard, element: MindElement) => {
     const node = MindElement.getNode(element);
     const layout = getCorrectLayout(board, element);
     if (isIndentedLayout(layout)) {
-        return getIndentedHierarchyLayoutDirection(layout);
+        return isRightLayout(layout) ? LayoutDirection.right : LayoutDirection.left;
     }
     return getNodeLayoutDirection(node, isHorizontalLayout(layout));
 };
 
-const getChildLayoutDirection = (board: PlaitBoard, source: MindElement, child: MindElement) => {
-    const layout = getCorrectLayout(board, child);
-    if (PlaitMind.isMind(source) && isIndentedLayout(layout)) {
-        return getIndentedBranchLayoutDirection(layout);
-    }
-    return getParentChildLayoutDirection(board, child);
-};
+type LayoutNavigationRelation = 'parent' | 'child' | 'previous-sibling' | 'next-sibling';
 
-const getVisibleSiblingByDirection = (board: PlaitBoard, source: MindElement, direction: Direction) => {
+interface LayoutNavigationCandidate {
+    element: MindElement;
+    relation: LayoutNavigationRelation;
+    direction: LayoutDirection;
+}
+
+const getLayoutNavigationCandidates = (board: PlaitBoard, source: MindElement): LayoutNavigationCandidate[] => {
+    const candidates: LayoutNavigationCandidate[] = [];
     const parent = getVisibleParent(source);
-    if (!parent) {
-        return undefined;
+
+    if (parent) {
+        const incomingDirection = resolveLayoutRelationDirection(board, {
+            type: 'parent-child',
+            parent,
+            child: source
+        });
+        candidates.push({
+            element: parent,
+            relation: 'parent',
+            direction: getLayoutReverseDirection(incomingDirection)
+        });
     }
-    const layout = getCorrectLayout(board, source);
-    const parentChildDirection = getParentChildLayoutDirection(board, source);
-    const previousSiblingDirection = isIndentedLayout(layout)
-        ? getLayoutReverseDirection(getIndentedBranchLayoutDirection(layout))
-        : isHorizontalDirection(LayoutDirectionToDirection[parentChildDirection])
-        ? LayoutDirection.top
-        : LayoutDirection.left;
-    const nextSiblingDirection = isIndentedLayout(layout)
-        ? getIndentedBranchLayoutDirection(layout)
-        : isHorizontalDirection(LayoutDirectionToDirection[parentChildDirection])
-        ? LayoutDirection.bottom
-        : LayoutDirection.right;
-    if (
-        direction !== LayoutDirectionToDirection[previousSiblingDirection] &&
-        direction !== LayoutDirectionToDirection[nextSiblingDirection]
-    ) {
-        return undefined;
+
+    getVisibleChildren(board, source).forEach((child) => {
+        candidates.push({
+            element: child,
+            relation: 'child',
+            direction: resolveLayoutRelationDirection(board, {
+                type: 'parent-child',
+                parent: source,
+                child
+            })
+        });
+    });
+
+    if (parent) {
+        const siblings = getVisibleChildren(board, parent);
+        const sourceIndex = siblings.indexOf(source);
+        if (sourceIndex !== -1) {
+            const previousSibling = siblings[sourceIndex - 1];
+            const nextSibling = siblings[sourceIndex + 1];
+
+            if (previousSibling) {
+                candidates.push({
+                    element: previousSibling,
+                    relation: 'previous-sibling',
+                    direction: resolveLayoutRelationDirection(board, {
+                        type: 'sibling',
+                        parent,
+                        order: 'previous'
+                    })
+                });
+            }
+
+            if (nextSibling) {
+                candidates.push({
+                    element: nextSibling,
+                    relation: 'next-sibling',
+                    direction: resolveLayoutRelationDirection(board, {
+                        type: 'sibling',
+                        parent,
+                        order: 'next'
+                    })
+                });
+            }
+        }
     }
-    const sourceLayoutDirection = getChildLayoutDirection(board, parent, source);
-    const siblings = getVisibleChildren(board, parent).filter(
-        (sibling) => getChildLayoutDirection(board, parent, sibling) === sourceLayoutDirection
-    );
-    const sourceIndex = siblings.indexOf(source);
-    if (sourceIndex === -1) {
-        return undefined;
-    }
-    if (direction === LayoutDirectionToDirection[previousSiblingDirection]) {
-        return siblings[sourceIndex - 1];
-    }
-    if (direction === LayoutDirectionToDirection[nextSiblingDirection]) {
-        return siblings[sourceIndex + 1];
-    }
-    return undefined;
+
+    return candidates;
 };
 
-const getParentOrChildByLayoutDirection = (board: PlaitBoard, source: MindElement, direction: Direction, previousElement?: MindElement) => {
-    const layoutDirection = DirectionToLayoutDirection[direction];
-    const parent = getVisibleParent(source);
-    if (parent && getLayoutReverseDirection(getChildLayoutDirection(board, parent, source)) === layoutDirection) {
-        return parent;
+const resolveLayoutNavigationTarget = (
+    candidates: LayoutNavigationCandidate[],
+    direction: LayoutDirection,
+    previousElement?: MindElement
+) => {
+    const matches = candidates.filter((candidate) => candidate.direction === direction);
+    const sibling = matches.find((candidate) => candidate.relation === 'previous-sibling' || candidate.relation === 'next-sibling');
+    if (sibling) {
+        return sibling.element;
     }
-    const children = getVisibleChildren(board, source);
-    if (
-        previousElement &&
-        children.includes(previousElement) &&
-        getChildLayoutDirection(board, source, previousElement) === layoutDirection
-    ) {
-        return previousElement;
-    }
-    return children.find((child) => getChildLayoutDirection(board, source, child) === layoutDirection);
-};
 
-const getNextMindElementByStructure = (board: PlaitBoard, source: MindElement, direction: Direction, previousElement?: MindElement) => {
-    return (
-        getVisibleSiblingByDirection(board, source, direction) ||
-        getParentOrChildByLayoutDirection(board, source, direction, previousElement)
-    );
+    const parent = matches.find((candidate) => candidate.relation === 'parent');
+    if (parent) {
+        return parent.element;
+    }
+
+    const children = matches.filter((candidate) => candidate.relation === 'child');
+    const rememberedChild = children.find((candidate) => candidate.element === previousElement);
+    return rememberedChild?.element || children[0]?.element;
 };
 
 const getNextMindElementByGeometry = (board: PlaitBoard, source: MindElement, direction: Direction) => {
@@ -203,16 +211,16 @@ const getNextMindElementByGeometry = (board: PlaitBoard, source: MindElement, di
         return undefined;
     }
     const root = MindElement.getRoot(board, source);
-    const sourceLayoutDirection = getParentChildLayoutDirection(board, source);
+    const sourceLayoutDirection = getGeometryLayoutDirection(board, source);
     const sourceDepth = getVisibleDepth(source);
     return getVisibleMindElements(board, root)
         .filter(
             (element) =>
                 element !== source &&
                 getVisibleDepth(element) === sourceDepth &&
-                getParentChildLayoutDirection(board, element) === sourceLayoutDirection &&
+                getGeometryLayoutDirection(board, element) === sourceLayoutDirection &&
                 isInNavigationDirection(direction, source, element) &&
-                hasCrossAxisOverlap(direction, source, element)
+                isInSameNavigationLane(direction, source, element)
         )
         .sort((a, b) => {
             const primaryDistance = getPrimaryDistance(direction, source, a) - getPrimaryDistance(direction, source, b);
@@ -229,7 +237,9 @@ export const getNextMindElementByDirection = (
     direction: Direction,
     previousElement?: MindElement
 ) => {
-    return (
-        getNextMindElementByStructure(board, source, direction, previousElement) || getNextMindElementByGeometry(board, source, direction)
-    );
+    const layoutDirection = DirectionToLayoutDirection[direction];
+    const candidates = getLayoutNavigationCandidates(board, source);
+    const layoutTarget = resolveLayoutNavigationTarget(candidates, layoutDirection, previousElement);
+
+    return layoutTarget || getNextMindElementByGeometry(board, source, direction);
 };

--- a/packages/mind/src/utils/position/navigation.ts
+++ b/packages/mind/src/utils/position/navigation.ts
@@ -1,7 +1,24 @@
 import { Direction, PlaitBoard, RectangleClient, depthFirstRecursion, getIsRecursionFunc, isHorizontalDirection } from '@plait/core';
-import { AbstractNode } from '@plait/layouts';
-import { MindElement } from '../../interfaces';
+import { AbstractNode, MindLayoutType, isHorizontalLayout, isIndentedLayout, isRightLayout, isTopLayout } from '@plait/layouts';
+import { LayoutDirection, MindElement, PlaitMind } from '../../interfaces';
+import { MindQueries } from '../../queries';
+import { getLayoutDirection as getNodeLayoutDirection } from '../point-placement';
+import { getLayoutReverseDirection } from '../layout';
 import { getRectangleByNode } from './node';
+
+const LayoutDirectionToDirection = {
+    [LayoutDirection.left]: Direction.left,
+    [LayoutDirection.right]: Direction.right,
+    [LayoutDirection.top]: Direction.top,
+    [LayoutDirection.bottom]: Direction.bottom
+};
+
+const DirectionToLayoutDirection = {
+    [Direction.left]: LayoutDirection.left,
+    [Direction.right]: LayoutDirection.right,
+    [Direction.top]: LayoutDirection.top,
+    [Direction.bottom]: LayoutDirection.bottom
+};
 
 export const getMindElementCenter = (element: MindElement) => {
     return RectangleClient.getCenterPoint(getRectangleByNode(MindElement.getNode(element)));
@@ -78,16 +95,43 @@ const getVisibleParent = (element: MindElement) => {
     return parent;
 };
 
-const isInHorizontalDirection = (source: MindElement, target: MindElement, direction: Direction) => {
-    const sourceCenter = getMindElementCenter(source);
-    const targetCenter = getMindElementCenter(target);
-    if (direction === Direction.left) {
-        return targetCenter[0] < sourceCenter[0];
+const getVisibleDepth = (element: MindElement) => {
+    let depth = 0;
+    let parent = getVisibleParent(element);
+    while (parent) {
+        depth++;
+        parent = getVisibleParent(parent);
     }
-    if (direction === Direction.right) {
-        return targetCenter[0] > sourceCenter[0];
+    return depth;
+};
+
+const getCorrectLayout = (board: PlaitBoard, element: MindElement) => {
+    return MindQueries.getCorrectLayoutByElement(board, element) as MindLayoutType;
+};
+
+const getIndentedHierarchyLayoutDirection = (layout: MindLayoutType) => {
+    return isRightLayout(layout) ? LayoutDirection.right : LayoutDirection.left;
+};
+
+const getIndentedBranchLayoutDirection = (layout: MindLayoutType) => {
+    return isTopLayout(layout) ? LayoutDirection.top : LayoutDirection.bottom;
+};
+
+const getParentChildLayoutDirection = (board: PlaitBoard, element: MindElement) => {
+    const node = MindElement.getNode(element);
+    const layout = getCorrectLayout(board, element);
+    if (isIndentedLayout(layout)) {
+        return getIndentedHierarchyLayoutDirection(layout);
     }
-    return false;
+    return getNodeLayoutDirection(node, isHorizontalLayout(layout));
+};
+
+const getChildLayoutDirection = (board: PlaitBoard, source: MindElement, child: MindElement) => {
+    const layout = getCorrectLayout(board, child);
+    if (PlaitMind.isMind(source) && isIndentedLayout(layout)) {
+        return getIndentedBranchLayoutDirection(layout);
+    }
+    return getParentChildLayoutDirection(board, child);
 };
 
 const getVisibleSiblingByDirection = (board: PlaitBoard, source: MindElement, direction: Direction) => {
@@ -95,50 +139,78 @@ const getVisibleSiblingByDirection = (board: PlaitBoard, source: MindElement, di
     if (!parent) {
         return undefined;
     }
-    const siblings = getVisibleChildren(board, parent);
+    const layout = getCorrectLayout(board, source);
+    const parentChildDirection = getParentChildLayoutDirection(board, source);
+    const previousSiblingDirection = isIndentedLayout(layout)
+        ? getLayoutReverseDirection(getIndentedBranchLayoutDirection(layout))
+        : isHorizontalDirection(LayoutDirectionToDirection[parentChildDirection])
+        ? LayoutDirection.top
+        : LayoutDirection.left;
+    const nextSiblingDirection = isIndentedLayout(layout)
+        ? getIndentedBranchLayoutDirection(layout)
+        : isHorizontalDirection(LayoutDirectionToDirection[parentChildDirection])
+        ? LayoutDirection.bottom
+        : LayoutDirection.right;
+    if (
+        direction !== LayoutDirectionToDirection[previousSiblingDirection] &&
+        direction !== LayoutDirectionToDirection[nextSiblingDirection]
+    ) {
+        return undefined;
+    }
+    const sourceLayoutDirection = getChildLayoutDirection(board, parent, source);
+    const siblings = getVisibleChildren(board, parent).filter(
+        (sibling) => getChildLayoutDirection(board, parent, sibling) === sourceLayoutDirection
+    );
     const sourceIndex = siblings.indexOf(source);
     if (sourceIndex === -1) {
         return undefined;
     }
-    if (direction === Direction.top) {
+    if (direction === LayoutDirectionToDirection[previousSiblingDirection]) {
         return siblings[sourceIndex - 1];
     }
-    if (direction === Direction.bottom) {
+    if (direction === LayoutDirectionToDirection[nextSiblingDirection]) {
         return siblings[sourceIndex + 1];
     }
     return undefined;
 };
 
-const getParentOrChildByHorizontalDirection = (
-    board: PlaitBoard,
-    source: MindElement,
-    direction: Direction,
-    previousElement?: MindElement
-) => {
+const getParentOrChildByLayoutDirection = (board: PlaitBoard, source: MindElement, direction: Direction, previousElement?: MindElement) => {
+    const layoutDirection = DirectionToLayoutDirection[direction];
     const parent = getVisibleParent(source);
-    if (parent && isInHorizontalDirection(source, parent, direction)) {
+    if (parent && getLayoutReverseDirection(getChildLayoutDirection(board, parent, source)) === layoutDirection) {
         return parent;
     }
     const children = getVisibleChildren(board, source);
-    if (previousElement && children.includes(previousElement) && isInHorizontalDirection(source, previousElement, direction)) {
+    if (
+        previousElement &&
+        children.includes(previousElement) &&
+        getChildLayoutDirection(board, source, previousElement) === layoutDirection
+    ) {
         return previousElement;
     }
-    return children.find((child) => isInHorizontalDirection(source, child, direction));
+    return children.find((child) => getChildLayoutDirection(board, source, child) === layoutDirection);
 };
 
 const getNextMindElementByStructure = (board: PlaitBoard, source: MindElement, direction: Direction, previousElement?: MindElement) => {
-    if (direction === Direction.left || direction === Direction.right) {
-        return getParentOrChildByHorizontalDirection(board, source, direction, previousElement);
-    }
-    return getVisibleSiblingByDirection(board, source, direction);
+    return (
+        getVisibleSiblingByDirection(board, source, direction) ||
+        getParentOrChildByLayoutDirection(board, source, direction, previousElement)
+    );
 };
 
 const getNextMindElementByGeometry = (board: PlaitBoard, source: MindElement, direction: Direction) => {
+    if (isIndentedLayout(getCorrectLayout(board, source))) {
+        return undefined;
+    }
     const root = MindElement.getRoot(board, source);
+    const sourceLayoutDirection = getParentChildLayoutDirection(board, source);
+    const sourceDepth = getVisibleDepth(source);
     return getVisibleMindElements(board, root)
         .filter(
             (element) =>
                 element !== source &&
+                getVisibleDepth(element) === sourceDepth &&
+                getParentChildLayoutDirection(board, element) === sourceLayoutDirection &&
                 isInNavigationDirection(direction, source, element) &&
                 hasCrossAxisOverlap(direction, source, element)
         )

--- a/packages/mind/src/utils/position/navigation.ts
+++ b/packages/mind/src/utils/position/navigation.ts
@@ -1,8 +1,6 @@
 import { Direction, PlaitBoard, RectangleClient, depthFirstRecursion, getIsRecursionFunc, isHorizontalDirection } from '@plait/core';
-import { AbstractNode, MindLayoutType, isHorizontalLayout, isIndentedLayout, isRightLayout } from '@plait/layouts';
+import { AbstractNode } from '@plait/layouts';
 import { LayoutDirection, MindElement } from '../../interfaces';
-import { MindQueries } from '../../queries';
-import { getLayoutDirection as getNodeLayoutDirection } from '../point-placement';
 import { getLayoutReverseDirection } from '../layout';
 import { resolveLayoutRelationDirection } from './layout-direction';
 import { getRectangleByNode } from './node';
@@ -42,22 +40,13 @@ const isInSameNavigationLane = (direction: Direction, source: MindElement, targe
     return RectangleClient.isHitX(sourceRectangle, targetRectangle);
 };
 
-const getPrimaryDistance = (direction: Direction, source: MindElement, target: MindElement) => {
+const getDistanceInNavigationDirection = (direction: Direction, source: MindElement, target: MindElement) => {
     const sourceCenter = getMindElementCenter(source);
     const targetCenter = getMindElementCenter(target);
     if (isHorizontalDirection(direction)) {
         return Math.abs(targetCenter[0] - sourceCenter[0]);
     }
     return Math.abs(targetCenter[1] - sourceCenter[1]);
-};
-
-const getSecondaryDistance = (direction: Direction, source: MindElement, target: MindElement) => {
-    const sourceCenter = getMindElementCenter(source);
-    const targetCenter = getMindElementCenter(target);
-    if (isHorizontalDirection(direction)) {
-        return Math.abs(targetCenter[1] - sourceCenter[1]);
-    }
-    return Math.abs(targetCenter[0] - sourceCenter[0]);
 };
 
 const getVisibleMindElements = (board: PlaitBoard, root: MindElement) => {
@@ -87,29 +76,6 @@ const getVisibleParent = (element: MindElement) => {
         parent = MindElement.findParent(parent);
     }
     return parent;
-};
-
-const getVisibleDepth = (element: MindElement) => {
-    let depth = 0;
-    let parent = getVisibleParent(element);
-    while (parent) {
-        depth++;
-        parent = getVisibleParent(parent);
-    }
-    return depth;
-};
-
-const getCorrectLayout = (board: PlaitBoard, element: MindElement) => {
-    return MindQueries.getCorrectLayoutByElement(board, element) as MindLayoutType;
-};
-
-const getGeometryLayoutDirection = (board: PlaitBoard, element: MindElement) => {
-    const node = MindElement.getNode(element);
-    const layout = getCorrectLayout(board, element);
-    if (isIndentedLayout(layout)) {
-        return isRightLayout(layout) ? LayoutDirection.right : LayoutDirection.left;
-    }
-    return getNodeLayoutDirection(node, isHorizontalLayout(layout));
 };
 
 type LayoutNavigationRelation = 'parent' | 'child' | 'previous-sibling' | 'next-sibling';
@@ -207,28 +173,15 @@ const resolveLayoutNavigationTarget = (
 };
 
 const getNextMindElementByGeometry = (board: PlaitBoard, source: MindElement, direction: Direction) => {
-    if (isIndentedLayout(getCorrectLayout(board, source))) {
-        return undefined;
-    }
     const root = MindElement.getRoot(board, source);
-    const sourceLayoutDirection = getGeometryLayoutDirection(board, source);
-    const sourceDepth = getVisibleDepth(source);
     return getVisibleMindElements(board, root)
         .filter(
             (element) =>
                 element !== source &&
-                getVisibleDepth(element) === sourceDepth &&
-                getGeometryLayoutDirection(board, element) === sourceLayoutDirection &&
                 isInNavigationDirection(direction, source, element) &&
                 isInSameNavigationLane(direction, source, element)
         )
-        .sort((a, b) => {
-            const primaryDistance = getPrimaryDistance(direction, source, a) - getPrimaryDistance(direction, source, b);
-            if (primaryDistance !== 0) {
-                return primaryDistance;
-            }
-            return getSecondaryDistance(direction, source, a) - getSecondaryDistance(direction, source, b);
-        })[0];
+        .sort((a, b) => getDistanceInNavigationDirection(direction, source, a) - getDistanceInNavigationDirection(direction, source, b))[0];
 };
 
 export const getNextMindElementByDirection = (

--- a/src/app/editor/editor.component.ts
+++ b/src/app/editor/editor.component.ts
@@ -22,7 +22,15 @@ import {
     PlaitPlugin,
     isHandMode
 } from '@plait/core';
-import { mockDrawData, mockTableData, mockMindData, mockRotateData, mockGroupData, mockSwimlaneData } from './mock-data';
+import {
+    mockDrawData,
+    mockTableData,
+    mockMindData,
+    mockRotateData,
+    mockGroupData,
+    mockSwimlaneData,
+    mockMindNavigationReviewData
+} from './mock-data';
 import { withMind, PlaitMindBoard, PlaitMind } from '@plait/mind';
 import { AbstractResizeState, MindThemeColors } from '@plait/mind';
 import { withMindExtend } from '../plugins/with-mind-extend';
@@ -111,6 +119,9 @@ export class BasicEditorComponent implements OnInit {
             switch (init) {
                 case 'mind':
                     this.value = [...mockMindData];
+                    break;
+                case 'mind-navigation-review':
+                    this.value = [...mockMindNavigationReviewData];
                     break;
                 case 'draw':
                     this.value = [...mockDrawData];

--- a/src/app/editor/mock-data.ts
+++ b/src/app/editor/mock-data.ts
@@ -1,5 +1,6 @@
 import { PlaitMind } from '@plait/mind';
 import { PlaitDrawElement } from '@plait/draw';
+import { MindLayoutType } from '@plait/layouts';
 
 /**
  * 数据结构说明
@@ -104,6 +105,352 @@ export const mockMindData: PlaitMind[] = [
             }
         ],
         points: [[560, 360]]
+    }
+];
+
+export const mockMindNavigationReviewData: PlaitMind[] = [
+    {
+        type: 'mind',
+        id: 'review-upward-complex',
+        layout: MindLayoutType.upward,
+        rightNodeCount: 8,
+        data: { topic: { children: [{ text: 'Central Topic' }] } },
+        children: [
+            {
+                id: 'up-discovery',
+                type: 'mind_child',
+                data: { topic: { children: [{ text: 'Discovery' }] } },
+                children: [
+                    {
+                        id: 'up-discovery-1',
+                        type: 'mind_child',
+                        data: { topic: { children: [{ text: 'Users' }] } },
+                        children: [
+                            {
+                                id: 'up-discovery-1-1',
+                                type: 'mind_child',
+                                data: { topic: { children: [{ text: 'Interviews' }] } },
+                                children: []
+                            },
+                            {
+                                id: 'up-discovery-1-2',
+                                type: 'mind_child',
+                                data: { topic: { children: [{ text: 'Support tickets' }] } },
+                                children: []
+                            }
+                        ]
+                    },
+                    {
+                        id: 'up-discovery-2',
+                        type: 'mind_child',
+                        data: { topic: { children: [{ text: 'Market' }] } },
+                        children: []
+                    }
+                ]
+            },
+            {
+                id: 'up-design',
+                type: 'mind_child',
+                data: { topic: { children: [{ text: 'Design' }] } },
+                children: [
+                    {
+                        id: 'up-design-1',
+                        type: 'mind_child',
+                        data: { topic: { children: [{ text: 'IA' }] } },
+                        children: []
+                    },
+                    {
+                        id: 'up-design-2',
+                        type: 'mind_child',
+                        data: { topic: { children: [{ text: 'Prototype' }] } },
+                        children: [
+                            {
+                                id: 'up-design-2-1',
+                                type: 'mind_child',
+                                data: { topic: { children: [{ text: 'Keyboard flow' }] } },
+                                children: []
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                id: 'up-build',
+                type: 'mind_child',
+                data: { topic: { children: [{ text: 'Build' }] } },
+                children: [
+                    {
+                        id: 'up-build-1',
+                        type: 'mind_child',
+                        data: { topic: { children: [{ text: 'Core logic' }] } },
+                        children: []
+                    }
+                ]
+            },
+            {
+                id: 'up-test',
+                type: 'mind_child',
+                data: { topic: { children: [{ text: 'Test' }] } },
+                children: [
+                    {
+                        id: 'up-test-1',
+                        type: 'mind_child',
+                        data: { topic: { children: [{ text: 'Upward layout' }] } },
+                        children: []
+                    },
+                    {
+                        id: 'up-test-2',
+                        type: 'mind_child',
+                        data: { topic: { children: [{ text: 'Fallback geometry' }] } },
+                        children: []
+                    }
+                ]
+            },
+            {
+                id: 'up-release',
+                type: 'mind_child',
+                data: { topic: { children: [{ text: 'Release' }] } },
+                children: []
+            }
+        ],
+        points: [[360, 760]]
+    },
+    {
+        type: 'mind',
+        id: 'review-right-top-indented-complex',
+        layout: MindLayoutType.rightTopIndented,
+        rightNodeCount: 8,
+        data: { topic: { children: [{ text: 'Central Topic' }] } },
+        children: [
+            {
+                id: 'indent-a',
+                type: 'mind_child',
+                data: { topic: { children: [{ text: 'A' }] } },
+                children: [
+                    {
+                        id: 'indent-a-1',
+                        type: 'mind_child',
+                        data: { topic: { children: [{ text: 'A-1' }] } },
+                        children: [
+                            {
+                                id: 'indent-a-1-1',
+                                type: 'mind_child',
+                                data: { topic: { children: [{ text: 'A-1-a' }] } },
+                                children: []
+                            },
+                            {
+                                id: 'indent-a-1-2',
+                                type: 'mind_child',
+                                data: { topic: { children: [{ text: 'A-1-b' }] } },
+                                children: []
+                            }
+                        ]
+                    },
+                    {
+                        id: 'indent-a-2',
+                        type: 'mind_child',
+                        data: { topic: { children: [{ text: 'A-2' }] } },
+                        children: []
+                    }
+                ]
+            },
+            {
+                id: 'indent-b',
+                type: 'mind_child',
+                data: { topic: { children: [{ text: '111' }] } },
+                children: [
+                    {
+                        id: 'indent-b-1',
+                        type: 'mind_child',
+                        data: { topic: { children: [{ text: '111-child' }] } },
+                        children: [
+                            {
+                                id: 'indent-b-1-1',
+                                type: 'mind_child',
+                                data: { topic: { children: [{ text: 'deep' }] } },
+                                children: [
+                                    {
+                                        id: 'indent-b-1-1-1',
+                                        type: 'mind_child',
+                                        data: { topic: { children: [{ text: 'deep-a' }] } },
+                                        children: []
+                                    }
+                                ]
+                            },
+                            {
+                                id: 'indent-b-1-2',
+                                type: 'mind_child',
+                                data: { topic: { children: [{ text: 'deep sibling' }] } },
+                                children: []
+                            }
+                        ]
+                    },
+                    {
+                        id: 'indent-b-2',
+                        type: 'mind_child',
+                        data: { topic: { children: [{ text: '111-note' }] } },
+                        children: []
+                    }
+                ]
+            },
+            {
+                id: 'indent-c',
+                type: 'mind_child',
+                data: { topic: { children: [{ text: 'C' }] } },
+                children: [
+                    {
+                        id: 'indent-c-1',
+                        type: 'mind_child',
+                        data: { topic: { children: [{ text: 'C-1' }] } },
+                        children: []
+                    },
+                    {
+                        id: 'indent-c-2',
+                        type: 'mind_child',
+                        data: { topic: { children: [{ text: 'C-2' }] } },
+                        children: []
+                    }
+                ]
+            },
+            {
+                id: 'indent-d',
+                type: 'mind_child',
+                data: { topic: { children: [{ text: 'D' }] } },
+                children: [
+                    {
+                        id: 'indent-d-1',
+                        type: 'mind_child',
+                        data: { topic: { children: [{ text: 'D-1' }] } },
+                        children: []
+                    }
+                ]
+            },
+            {
+                id: 'indent-e',
+                type: 'mind_child',
+                data: { topic: { children: [{ text: 'E boundary' }] } },
+                children: []
+            }
+        ],
+        points: [[900, 820]]
+    },
+    {
+        type: 'mind',
+        id: 'review-standard-summary-complex',
+        layout: MindLayoutType.standard,
+        rightNodeCount: 4,
+        data: { topic: { children: [{ text: 'Central Topic' }] } },
+        children: [
+            {
+                id: 'std-a',
+                type: 'mind_child',
+                data: { topic: { children: [{ text: 'A right top' }] } },
+                children: [
+                    {
+                        id: 'std-a-1',
+                        type: 'mind_child',
+                        data: { topic: { children: [{ text: 'A child' }] } },
+                        children: []
+                    }
+                ]
+            },
+            {
+                id: 'std-b',
+                type: 'mind_child',
+                data: { topic: { children: [{ text: 'B right mid' }] } },
+                children: [
+                    {
+                        id: 'std-b-1',
+                        type: 'mind_child',
+                        data: { topic: { children: [{ text: 'B child 1' }] } },
+                        children: []
+                    },
+                    {
+                        id: 'std-b-2',
+                        type: 'mind_child',
+                        data: { topic: { children: [{ text: 'B child 2' }] } },
+                        children: []
+                    }
+                ]
+            },
+            {
+                id: 'std-c',
+                type: 'mind_child',
+                data: { topic: { children: [{ text: '111 right' }] } },
+                children: [
+                    {
+                        id: 'std-c-1',
+                        type: 'mind_child',
+                        data: { topic: { children: [{ text: '111-child' }] } },
+                        children: [
+                            {
+                                id: 'std-c-1-1',
+                                type: 'mind_child',
+                                data: { topic: { children: [{ text: 'deep' }] } },
+                                children: []
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                id: 'std-d',
+                type: 'mind_child',
+                data: { topic: { children: [{ text: 'D right bottom' }] } },
+                children: []
+            },
+            {
+                id: 'std-e',
+                type: 'mind_child',
+                data: { topic: { children: [{ text: 'E left top' }] } },
+                children: [
+                    {
+                        id: 'std-e-1',
+                        type: 'mind_child',
+                        data: { topic: { children: [{ text: 'E child' }] } },
+                        children: []
+                    }
+                ]
+            },
+            {
+                id: 'std-f',
+                type: 'mind_child',
+                data: { topic: { children: [{ text: 'F left mid' }] } },
+                children: []
+            },
+            {
+                id: 'std-g',
+                type: 'mind_child',
+                data: { topic: { children: [{ text: 'G left lower' }] } },
+                children: [
+                    {
+                        id: 'std-g-1',
+                        type: 'mind_child',
+                        data: { topic: { children: [{ text: 'G child' }] } },
+                        children: []
+                    }
+                ]
+            },
+            {
+                id: 'std-h',
+                type: 'mind_child',
+                data: { topic: { children: [{ text: 'H left boundary' }] } },
+                children: []
+            },
+            {
+                id: 'std-summary',
+                type: 'mind_child',
+                data: { topic: { children: [{ text: 'Summary right group' }] } },
+                children: [],
+                strokeColor: '#AAAAAA',
+                strokeWidth: 2,
+                branchColor: '#AAAAAA',
+                branchWidth: 2,
+                start: 1,
+                end: 3
+            }
+        ],
+        points: [[1520, 760]]
     }
 ];
 

--- a/src/app/editor/mock-data.ts
+++ b/src/app/editor/mock-data.ts
@@ -108,13 +108,21 @@ export const mockMindData: PlaitMind[] = [
     }
 ];
 
+/**
+ * Manual review route: /?init=mind-navigation-review
+ *
+ * Nested ownership: outer root Up -> A, A Down -> root, A Up -> B,
+ * B Down -> A, A Right -> A-1, A-1 Up -> A-2 -> 111,
+ * then 111 Down -> A-2 -> A-1.
+ * Standard boundary: D Down -> E, E Up -> D.
+ */
 export const mockMindNavigationReviewData: PlaitMind[] = [
     {
         type: 'mind',
         id: 'review-upward-complex',
         layout: MindLayoutType.upward,
         rightNodeCount: 8,
-        data: { topic: { children: [{ text: 'Central Topic' }] } },
+        data: { topic: { children: [{ text: 'Upward layout' }] } },
         children: [
             {
                 id: 'up-discovery',
@@ -220,17 +228,18 @@ export const mockMindNavigationReviewData: PlaitMind[] = [
         id: 'review-right-top-indented-complex',
         layout: MindLayoutType.rightTopIndented,
         rightNodeCount: 8,
-        data: { topic: { children: [{ text: 'Central Topic' }] } },
+        data: { topic: { children: [{ text: 'Outer rightTopIndented' }] } },
         children: [
             {
                 id: 'indent-a',
                 type: 'mind_child',
-                data: { topic: { children: [{ text: 'A' }] } },
+                layout: MindLayoutType.right,
+                data: { topic: { children: [{ text: 'A · nested right' }] } },
                 children: [
                     {
                         id: 'indent-a-1',
                         type: 'mind_child',
-                        data: { topic: { children: [{ text: 'A-1' }] } },
+                        data: { topic: { children: [{ text: 'A-1 · nested child' }] } },
                         children: [
                             {
                                 id: 'indent-a-1-1',
@@ -249,7 +258,13 @@ export const mockMindNavigationReviewData: PlaitMind[] = [
                     {
                         id: 'indent-a-2',
                         type: 'mind_child',
-                        data: { topic: { children: [{ text: 'A-2' }] } },
+                        data: { topic: { children: [{ text: 'A-2 · nested child' }] } },
+                        children: []
+                    },
+                    {
+                        id: 'indent-a-3',
+                        type: 'mind_child',
+                        data: { topic: { children: [{ text: '111 · nested child' }] } },
                         children: []
                     }
                 ]
@@ -257,7 +272,7 @@ export const mockMindNavigationReviewData: PlaitMind[] = [
             {
                 id: 'indent-b',
                 type: 'mind_child',
-                data: { topic: { children: [{ text: '111' }] } },
+                data: { topic: { children: [{ text: 'B · outer sibling' }] } },
                 children: [
                     {
                         id: 'indent-b-1',
@@ -339,7 +354,7 @@ export const mockMindNavigationReviewData: PlaitMind[] = [
         id: 'review-standard-summary-complex',
         layout: MindLayoutType.standard,
         rightNodeCount: 4,
-        data: { topic: { children: [{ text: 'Central Topic' }] } },
+        data: { topic: { children: [{ text: 'Standard split boundary' }] } },
         children: [
             {
                 id: 'std-a',
@@ -396,13 +411,13 @@ export const mockMindNavigationReviewData: PlaitMind[] = [
             {
                 id: 'std-d',
                 type: 'mind_child',
-                data: { topic: { children: [{ text: 'D right bottom' }] } },
+                data: { topic: { children: [{ text: 'D · last right' }] } },
                 children: []
             },
             {
                 id: 'std-e',
                 type: 'mind_child',
-                data: { topic: { children: [{ text: 'E left top' }] } },
+                data: { topic: { children: [{ text: 'E · first left' }] } },
                 children: [
                     {
                         id: 'std-e-1',


### PR DESCRIPTION
## Summary

- Add arrow-key navigation for a single selected child mind node while preserving root-mind movement and text-editing behavior.
- Navigate by visible mind-map structure first: parent, children, previous sibling, and next sibling are collected as layout-aware relationship candidates.
- Resolve each relationship from the layout context that owns it, including nested layouts.
- Resolve direction conflicts explicitly with this priority: sibling → parent → remembered child → first child.
- Keep geometry lookup isolated as a fallback only when no layout candidate matches.

## Why

A selected node can participate in relationships owned by different layout contexts. In a nested `rightTopIndented -> right` tree, the outer layout owns the node's incoming edge and sibling sequence, while the nested `right` layout owns its descendants.

Nested subtrees may also be mirrored by an ancestor. Sibling navigation therefore uses the common parent's final rendered `up` / `left` orientation instead of relying only on the declared layout enum. This prevents loops such as `A-1 -> A-2 -> A-1` when navigating a mirrored three-sibling subtree.

## Scope

This PR covers layout-based keyboard navigation and keeps the existing geometry lookup as an isolated fallback. Broader geometry policy changes and shared rendered-direction refactors for Node More, DnD, link drawing, and other callers remain follow-up work.

## Validation

- `npx ng test mind --watch=false --progress=false --browsers=ChromeHeadless --include=packages/mind/src/plugins/with-mind-hotkey.spec.ts` — 24 specs passed
- `npx ng test mind --watch=false --progress=false --browsers=ChromeHeadless` — 45 specs passed
- `npm run build:mind`
- `npm run build:demo`
- Targeted ESLint, Prettier, and `git diff --check` for the changed files
- Manual review route: `http://localhost:4200/?init=mind-navigation-review`
  - `A-1 ↑ A-2 ↑ 111`
  - `111 ↓ A-2 ↓ A-1`
  - standard boundary: `D ↓ E ↑ D`