### PR TITLE
Support SVG clipboard paste

### DIFF
--- a/.changeset/svg-clipboard-paste.md
+++ b/.changeset/svg-clipboard-paste.md
@@ -1,0 +1,6 @@
+---
+'@plait/core': patch
+'@plait/common': patch
+---
+
+Support pasting SVG clipboard content as an image file.

--- a/packages/common/src/constants/media.ts
+++ b/packages/common/src/constants/media.ts
@@ -4,6 +4,6 @@ export enum MediaKeys {
 
 export const PICTURE_ACCEPTED_UPLOAD_SIZE = 20;
 
-export const acceptImageTypes = ['png', 'jpeg', 'gif', 'bmp'];
+export const acceptImageTypes = ['png', 'jpeg', 'gif', 'bmp', 'svg+xml'];
 
 export const WithCommonPluginKey = 'plait-common-plugin-key';

--- a/packages/core/src/utils/clipboard/clipboard.spec.ts
+++ b/packages/core/src/utils/clipboard/clipboard.spec.ts
@@ -1,0 +1,171 @@
+import { buildPlaitHtml } from './common';
+import { getClipboardData } from './clipboard';
+import { WritableClipboardType } from './types';
+
+const SVG_MIME_TYPE = 'image/svg+xml';
+
+const readFileText = (file: File) => {
+    return new Promise<string>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.addEventListener('loadend', () => resolve(reader.result as string));
+        reader.addEventListener('error', () => reject(reader.error));
+        reader.readAsText(file);
+    });
+};
+
+const createSvgDataTransferItem = (svg: string) => {
+    return {
+        kind: 'string',
+        type: SVG_MIME_TYPE,
+        getAsString: (callback: FunctionStringCallback | null) => callback?.(svg)
+    } as DataTransferItem;
+};
+
+const createDataTransfer = ({
+    html = '',
+    text = '',
+    svg = '',
+    items = []
+}: {
+    html?: string;
+    text?: string;
+    svg?: string;
+    items?: DataTransferItem[];
+}) => {
+    return {
+        files: { length: 0 },
+        items,
+        getData: (type: string) => {
+            if (type === 'text/html') {
+                return html;
+            }
+            if (type === 'text/plain') {
+                return text;
+            }
+            if (type === SVG_MIME_TYPE) {
+                return svg;
+            }
+            return '';
+        }
+    } as unknown as DataTransfer;
+};
+
+describe('getClipboardData', () => {
+    let originalClipboard: Clipboard | undefined;
+    let originalClipboardItem: typeof ClipboardItem | undefined;
+
+    beforeEach(() => {
+        originalClipboard = navigator.clipboard;
+        originalClipboardItem = window.ClipboardItem;
+    });
+
+    afterEach(() => {
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: originalClipboard
+        });
+        (window as any).ClipboardItem = originalClipboardItem;
+    });
+
+    it('should read SVG clipboard content from string data transfer item as a file', async () => {
+        const svg = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>';
+        const dataTransfer = createDataTransfer({
+            items: [createSvgDataTransferItem(svg)]
+        });
+
+        const clipboardData = await getClipboardData(dataTransfer);
+        const file = clipboardData?.files?.[0];
+
+        expect(file).toBeTruthy();
+        expect(file?.name).toBe('plait-svg-image.svg');
+        expect(file?.type).toBe(SVG_MIME_TYPE);
+        expect(file && (await readFileText(file))).toBe(svg);
+    });
+
+    it('should keep Plait HTML clipboard data before SVG clipboard content', async () => {
+        const element = { id: 'geometry', type: 'geometry', points: [] };
+        const dataTransfer = createDataTransfer({
+            html: buildPlaitHtml(WritableClipboardType.elements, [element]),
+            items: [createSvgDataTransferItem('<svg xmlns="http://www.w3.org/2000/svg"></svg>')]
+        });
+
+        const clipboardData = await getClipboardData(dataTransfer);
+
+        expect(clipboardData?.elements).toEqual([element]);
+        expect(clipboardData?.files).toBeUndefined();
+    });
+
+    it('should read SVG clipboard content from data transfer MIME data', async () => {
+        const svg = '<svg xmlns="http://www.w3.org/2000/svg"><circle r="5"/></svg>';
+        const dataTransfer = createDataTransfer({ svg });
+
+        const clipboardData = await getClipboardData(dataTransfer);
+        const file = clipboardData?.files?.[0];
+
+        expect(file).toBeTruthy();
+        expect(file?.type).toBe(SVG_MIME_TYPE);
+        expect(file && (await readFileText(file))).toBe(svg);
+    });
+
+    it('should fall back to navigator clipboard when SVG data transfer item has no string data', async () => {
+        const svg = '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0h10v10z"/></svg>';
+        class MockClipboardItem {
+            types = [SVG_MIME_TYPE];
+
+            async getType(type: string) {
+                return new Blob([svg], { type });
+            }
+        }
+        (window as any).ClipboardItem = MockClipboardItem;
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: {
+                read: () => Promise.resolve([new MockClipboardItem()])
+            }
+        });
+        const dataTransfer = createDataTransfer({
+            items: [createSvgDataTransferItem('')]
+        });
+
+        const clipboardData = await getClipboardData(dataTransfer);
+        const file = clipboardData?.files?.[0];
+
+        expect(file).toBeTruthy();
+        expect(file?.type).toBe(SVG_MIME_TYPE);
+        expect(file && (await readFileText(file))).toBe(svg);
+    });
+
+    it('should preserve SVG type before async string reading invalidates data transfer items', async () => {
+        const svg = '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0h20v20z"/></svg>';
+        class MockClipboardItem {
+            types = [SVG_MIME_TYPE];
+
+            async getType(type: string) {
+                return new Blob([svg], { type });
+            }
+        }
+        (window as any).ClipboardItem = MockClipboardItem;
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: {
+                read: () => Promise.resolve([new MockClipboardItem()])
+            }
+        });
+        let itemsAccessCount = 0;
+        const dataTransfer = {
+            files: { length: 0 },
+            get items() {
+                itemsAccessCount++;
+                return itemsAccessCount === 1 ? [createSvgDataTransferItem('')] : [];
+            },
+            getData: () => ''
+        } as unknown as DataTransfer;
+
+        const clipboardData = await getClipboardData(dataTransfer);
+        const file = clipboardData?.files?.[0];
+
+        expect(file).toBeTruthy();
+        expect(file?.type).toBe(SVG_MIME_TYPE);
+        expect(file && (await readFileText(file))).toBe(svg);
+    });
+});

--- a/packages/core/src/utils/clipboard/clipboard.spec.ts
+++ b/packages/core/src/utils/clipboard/clipboard.spec.ts
@@ -13,11 +13,16 @@ const readFileText = (file: File) => {
     });
 };
 
-const createSvgDataTransferItem = (svg: string) => {
+const createSvgDataTransferItem = (svg: string, onRead?: () => void) => {
     return {
         kind: 'string',
         type: SVG_MIME_TYPE,
-        getAsString: (callback: FunctionStringCallback | null) => callback?.(svg)
+        getAsString: (callback: FunctionStringCallback | null) => {
+            queueMicrotask(() => {
+                onRead?.();
+                callback?.(svg);
+            });
+        }
     } as DataTransferItem;
 };
 
@@ -51,20 +56,18 @@ const createDataTransfer = ({
 };
 
 describe('getClipboardData', () => {
-    let originalClipboard: Clipboard | undefined;
-    let originalClipboardItem: typeof ClipboardItem | undefined;
+    let originalClipboardDescriptor: PropertyDescriptor | undefined;
 
     beforeEach(() => {
-        originalClipboard = navigator.clipboard;
-        originalClipboardItem = window.ClipboardItem;
+        originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
     });
 
     afterEach(() => {
-        Object.defineProperty(navigator, 'clipboard', {
-            configurable: true,
-            value: originalClipboard
-        });
-        (window as any).ClipboardItem = originalClipboardItem;
+        if (originalClipboardDescriptor) {
+            Object.defineProperty(navigator, 'clipboard', originalClipboardDescriptor);
+        } else {
+            Reflect.deleteProperty(navigator, 'clipboard');
+        }
     });
 
     it('should read SVG clipboard content from string data transfer item as a file', async () => {
@@ -107,23 +110,14 @@ describe('getClipboardData', () => {
         expect(file && (await readFileText(file))).toBe(svg);
     });
 
-    it('should fall back to navigator clipboard when SVG data transfer item has no string data', async () => {
+    it('should use synchronous SVG MIME data when the SVG item string is empty', async () => {
         const svg = '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0h10v10z"/></svg>';
-        class MockClipboardItem {
-            types = [SVG_MIME_TYPE];
-
-            async getType(type: string) {
-                return new Blob([svg], { type });
-            }
-        }
-        (window as any).ClipboardItem = MockClipboardItem;
         Object.defineProperty(navigator, 'clipboard', {
             configurable: true,
-            value: {
-                read: () => Promise.resolve([new MockClipboardItem()])
-            }
+            value: {}
         });
         const dataTransfer = createDataTransfer({
+            svg,
             items: [createSvgDataTransferItem('')]
         });
 
@@ -135,37 +129,34 @@ describe('getClipboardData', () => {
         expect(file && (await readFileText(file))).toBe(svg);
     });
 
-    it('should preserve SVG type before async string reading invalidates data transfer items', async () => {
-        const svg = '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0h20v20z"/></svg>';
-        class MockClipboardItem {
-            types = [SVG_MIME_TYPE];
-
-            async getType(type: string) {
-                return new Blob([svg], { type });
-            }
-        }
-        (window as any).ClipboardItem = MockClipboardItem;
+    it('should preserve plain text before async SVG reading without using navigator clipboard', async () => {
+        const text = 'plain text clipboard data';
+        let dataTransferReadable = true;
+        const read = jasmine.createSpy('read').and.callFake(() => Promise.reject(new Error('unexpected navigator clipboard read')));
         Object.defineProperty(navigator, 'clipboard', {
             configurable: true,
             value: {
-                read: () => Promise.resolve([new MockClipboardItem()])
+                read
             }
         });
-        let itemsAccessCount = 0;
         const dataTransfer = {
             files: { length: 0 },
-            get items() {
-                itemsAccessCount++;
-                return itemsAccessCount === 1 ? [createSvgDataTransferItem('')] : [];
-            },
-            getData: () => ''
+            items: [
+                createSvgDataTransferItem('', () => {
+                    dataTransferReadable = false;
+                })
+            ],
+            getData: (type: string) => {
+                if (!dataTransferReadable) {
+                    return '';
+                }
+                return type === 'text/plain' ? text : '';
+            }
         } as unknown as DataTransfer;
 
         const clipboardData = await getClipboardData(dataTransfer);
-        const file = clipboardData?.files?.[0];
 
-        expect(file).toBeTruthy();
-        expect(file?.type).toBe(SVG_MIME_TYPE);
-        expect(file && (await readFileText(file))).toBe(svg);
+        expect(clipboardData?.text).toBe(text);
+        expect(read).not.toHaveBeenCalled();
     });
 });

--- a/packages/core/src/utils/clipboard/clipboard.ts
+++ b/packages/core/src/utils/clipboard/clipboard.ts
@@ -13,6 +13,38 @@ import {
 import { getNavigatorClipboard, setNavigatorClipboard } from './navigator-clipboard';
 import { ClipboardData, WritableClipboardContext } from './types';
 
+const SVG_MIME_TYPE = 'image/svg+xml';
+
+const getStringFromDataTransferItem = (item: DataTransferItem) => {
+    return new Promise<string>((resolve) => {
+        item.getAsString((value) => {
+            resolve(value || '');
+        });
+    });
+};
+
+const getSvgClipboardData = async (dataTransfer: DataTransfer): Promise<ClipboardData | null> => {
+    const svgItem = Array.from(dataTransfer.items || []).find((item) => item.kind === 'string' && item.type === SVG_MIME_TYPE);
+    const svgText = svgItem ? await getStringFromDataTransferItem(svgItem) : dataTransfer.getData(SVG_MIME_TYPE);
+    if (!svgText.trim()) {
+        return null;
+    }
+    return {
+        files: [new File([svgText], 'plait-svg-image.svg', { type: SVG_MIME_TYPE })]
+    };
+};
+
+const getNavigatorClipboardSafely = async (): Promise<ClipboardData> => {
+    if (!getProbablySupportsClipboardRead()) {
+        return {};
+    }
+    try {
+        return await getNavigatorClipboard();
+    } catch {
+        return {};
+    }
+};
+
 export const cacheClipboardData = (clipboardData: ClipboardData) => {
     (window as any)['plait_fallback_clipboard_data'] = clipboardData;
 };
@@ -22,21 +54,30 @@ export const getCachedClipboardData = () => {
 };
 
 export const getClipboardData = async (dataTransfer: DataTransfer | null): Promise<ClipboardData | null> => {
-    let clipboardData = {};
+    let clipboardData: ClipboardData = {};
     if (dataTransfer) {
         if (dataTransfer.files.length) {
             return { files: Array.from(dataTransfer.files) };
         }
         clipboardData = getDataTransferClipboard(dataTransfer);
-        if (Object.keys(clipboardData).length === 0) {
-            clipboardData = getDataTransferClipboardText(dataTransfer);
+        if (Object.keys(clipboardData).length > 0) {
+            return clipboardData;
+        }
+        const svgClipboardData = await getSvgClipboardData(dataTransfer);
+        if (svgClipboardData) {
+            return svgClipboardData;
+        }
+        clipboardData = getDataTransferClipboardText(dataTransfer);
+        if (Object.keys(clipboardData).length > 0 && clipboardData.text) {
+            return clipboardData;
+        }
+        const navigatorClipboardData = await getNavigatorClipboardSafely();
+        if (Object.keys(navigatorClipboardData).length > 0) {
+            return navigatorClipboardData;
         }
         return clipboardData;
     }
-    if (getProbablySupportsClipboardRead()) {
-        return await getNavigatorClipboard();
-    }
-    return null;
+    return await getNavigatorClipboardSafely();
 };
 
 export const setClipboardData = async (dataTransfer: DataTransfer | null, clipboardContext: WritableClipboardContext | null) => {

--- a/packages/core/src/utils/clipboard/clipboard.ts
+++ b/packages/core/src/utils/clipboard/clipboard.ts
@@ -15,7 +15,7 @@ import { ClipboardData, WritableClipboardContext } from './types';
 
 const SVG_MIME_TYPE = 'image/svg+xml';
 
-const getStringFromDataTransferItem = (item: DataTransferItem) => {
+const readDataTransferItemAsString = (item: DataTransferItem): Promise<string> => {
     return new Promise<string>((resolve) => {
         item.getAsString((value) => {
             resolve(value || '');
@@ -23,30 +23,20 @@ const getStringFromDataTransferItem = (item: DataTransferItem) => {
     });
 };
 
-const getSvgClipboardData = async (dataTransfer: DataTransfer): Promise<ClipboardData | null> => {
+const readSvgText = async (dataTransfer: DataTransfer): Promise<string> => {
+    const svgText = dataTransfer.getData(SVG_MIME_TYPE);
     const svgItem = Array.from(dataTransfer.items || []).find((item) => item.kind === 'string' && item.type === SVG_MIME_TYPE);
-    const svgText = svgItem ? await getStringFromDataTransferItem(svgItem) : dataTransfer.getData(SVG_MIME_TYPE);
-    if (!svgText.trim()) {
-        return null;
+    if (svgText.trim()) {
+        return svgText;
     }
+
+    return svgItem ? await readDataTransferItemAsString(svgItem) : '';
+};
+
+const createSvgClipboardData = (svgText: string): ClipboardData => {
     return {
         files: [new File([svgText], 'plait-svg-image.svg', { type: SVG_MIME_TYPE })]
     };
-};
-
-const hasSvgClipboardType = (dataTransfer: DataTransfer) => {
-    return Array.from(dataTransfer.items || []).some((item) => item.type === SVG_MIME_TYPE);
-};
-
-const getNavigatorClipboardSafely = async (): Promise<ClipboardData> => {
-    if (!getProbablySupportsClipboardRead()) {
-        return {};
-    }
-    try {
-        return await getNavigatorClipboard();
-    } catch {
-        return {};
-    }
 };
 
 export const cacheClipboardData = (clipboardData: ClipboardData) => {
@@ -58,28 +48,22 @@ export const getCachedClipboardData = () => {
 };
 
 export const getClipboardData = async (dataTransfer: DataTransfer | null): Promise<ClipboardData | null> => {
-    let clipboardData: ClipboardData = {};
     if (dataTransfer) {
         if (dataTransfer.files.length) {
             return { files: Array.from(dataTransfer.files) };
         }
-        const hasSvgType = hasSvgClipboardType(dataTransfer);
-        clipboardData = getDataTransferClipboard(dataTransfer);
-        if (Object.keys(clipboardData).length > 0) {
-            return clipboardData;
+        const plaitClipboardData = getDataTransferClipboard(dataTransfer);
+        if (Object.keys(plaitClipboardData).length > 0) {
+            return plaitClipboardData;
         }
-        const svgClipboardData = await getSvgClipboardData(dataTransfer);
-        if (svgClipboardData) {
-            return svgClipboardData;
+        const svgTextPromise = readSvgText(dataTransfer);
+        // DataTransfer is event-scoped, so preserve the plain-text fallback before awaiting the SVG item.
+        const textClipboardData = getDataTransferClipboardText(dataTransfer);
+        const svgText = await svgTextPromise;
+        if (svgText.trim()) {
+            return createSvgClipboardData(svgText);
         }
-        if (hasSvgType) {
-            const navigatorClipboardData = await getNavigatorClipboardSafely();
-            if (navigatorClipboardData.files?.length) {
-                return navigatorClipboardData;
-            }
-        }
-        clipboardData = getDataTransferClipboardText(dataTransfer);
-        return clipboardData;
+        return textClipboardData;
     }
     if (getProbablySupportsClipboardRead()) {
         return await getNavigatorClipboard();

--- a/packages/core/src/utils/clipboard/clipboard.ts
+++ b/packages/core/src/utils/clipboard/clipboard.ts
@@ -34,6 +34,10 @@ const getSvgClipboardData = async (dataTransfer: DataTransfer): Promise<Clipboar
     };
 };
 
+const hasSvgClipboardType = (dataTransfer: DataTransfer) => {
+    return Array.from(dataTransfer.items || []).some((item) => item.type === SVG_MIME_TYPE);
+};
+
 const getNavigatorClipboardSafely = async (): Promise<ClipboardData> => {
     if (!getProbablySupportsClipboardRead()) {
         return {};
@@ -59,6 +63,7 @@ export const getClipboardData = async (dataTransfer: DataTransfer | null): Promi
         if (dataTransfer.files.length) {
             return { files: Array.from(dataTransfer.files) };
         }
+        const hasSvgType = hasSvgClipboardType(dataTransfer);
         clipboardData = getDataTransferClipboard(dataTransfer);
         if (Object.keys(clipboardData).length > 0) {
             return clipboardData;
@@ -67,17 +72,19 @@ export const getClipboardData = async (dataTransfer: DataTransfer | null): Promi
         if (svgClipboardData) {
             return svgClipboardData;
         }
+        if (hasSvgType) {
+            const navigatorClipboardData = await getNavigatorClipboardSafely();
+            if (navigatorClipboardData.files?.length) {
+                return navigatorClipboardData;
+            }
+        }
         clipboardData = getDataTransferClipboardText(dataTransfer);
-        if (Object.keys(clipboardData).length > 0 && clipboardData.text) {
-            return clipboardData;
-        }
-        const navigatorClipboardData = await getNavigatorClipboardSafely();
-        if (Object.keys(navigatorClipboardData).length > 0) {
-            return navigatorClipboardData;
-        }
         return clipboardData;
     }
-    return await getNavigatorClipboardSafely();
+    if (getProbablySupportsClipboardRead()) {
+        return await getNavigatorClipboard();
+    }
+    return null;
 };
 
 export const setClipboardData = async (dataTransfer: DataTransfer | null, clipboardContext: WritableClipboardContext | null) => {


### PR DESCRIPTION
## Summary

- Detect `image/svg+xml` clipboard entries and convert them into image files for the existing paste flow.
- Add SVG to the accepted image MIME types.
- Add clipboard tests for SVG string data, `getData`, and navigator clipboard fallback paths.

## Testing

- `npx ng test core --watch=false --progress=false --browsers=ChromeHeadlessCI --include=packages/core/src/utils/clipboard/clipboard.spec.ts`
- `npm run build:core`
- `npm run build:common`
- Verified locally in Drawnix by pasting an SVG-only clipboard item.