### PR TITLE
fix(draw): adjust table cell edge resize

### DIFF
--- a/.changeset/fresh-table-resize.md
+++ b/.changeset/fresh-table-resize.md
@@ -1,0 +1,5 @@
+---
+'@plait/draw': patch
+---
+
+Adjust table cell edge resize behavior

--- a/packages/draw/src/plugins/with-table-resize.ts
+++ b/packages/draw/src/plugins/with-table-resize.ts
@@ -13,7 +13,7 @@ import {
 } from '@plait/common';
 import { getCellsWithPoints, getCurrentRowOrColumnSize, ResizeEdge, updateColumns, updateRows } from '../utils/table';
 import { getHitRectangleResizeHandleRef } from '../utils/position/geometry';
-import { getResizeOriginPointAndHandlePoint, getResizeZoom, movePointByZoomAndOriginPoint } from './with-draw-resize';
+import { getResizeOriginPointAndHandlePoint } from './with-draw-resize';
 import { getSnapResizingRef, getSnapResizingRefOptions } from '../utils/snap-resizing';
 import { PlaitDrawElement } from '../interfaces';
 import { isSingleSelectTable } from '../utils';
@@ -41,11 +41,24 @@ export function withTableResize(board: PlaitTableBoard) {
             const hitElement = selectedElements[0];
             // debugGenerator.clear();
             if (hitElement && PlaitDrawElement.isElementByTable(hitElement)) {
+                const tableRectangle = board.getRectangle(hitElement) as RectangleClient;
+                // debugGenerator.drawRectangle(board, tableRectangle);
+                // debugGenerator.drawCircles(board, [point], 5);
+                const tableHandleRef = getHitRectangleResizeHandleRef(board, tableRectangle, point, hitElement.angle);
+                if (tableHandleRef && isCornerHandle(board, tableHandleRef.handle)) {
+                    return {
+                        element: hitElement,
+                        handle: tableHandleRef.handle,
+                        cursorClass: tableHandleRef.cursorClass,
+                        rectangle: tableRectangle
+                    };
+                }
+
                 const cells = getCellsWithPoints(board, hitElement);
                 for (let i = 0; i < cells.length; i++) {
                     const rectangle = RectangleClient.getRectangleByPoints(cells[i].points);
-                    const handleRef = getHitRectangleResizeHandleRef(board, rectangle, point, 0);
-                    if (handleRef && !isCornerHandle(board, handleRef.handle)) {
+                    const handleRef = getHitRectangleResizeHandleRef(board, rectangle, point, 0, true);
+                    if (handleRef) {
                         return {
                             element: hitElement,
                             handle: handleRef.handle,
@@ -57,19 +70,6 @@ export function withTableResize(board: PlaitTableBoard) {
                         };
                     }
                 }
-
-                const rectangle = board.getRectangle(hitElement) as RectangleClient;
-                // debugGenerator.drawRectangle(board, rectangle);
-                // debugGenerator.drawCircles(board, [point], 5);
-                const handleRef = getHitRectangleResizeHandleRef(board, rectangle, point, hitElement.angle);
-                if (handleRef && isCornerHandle(board, handleRef.handle)) {
-                    return {
-                        element: hitElement,
-                        handle: handleRef.handle,
-                        cursorClass: handleRef.cursorClass,
-                        rectangle
-                    };
-                }
             }
             return null;
         },
@@ -78,44 +78,40 @@ export function withTableResize(board: PlaitTableBoard) {
             const path = PlaitBoard.findPath(board, resizeRef.element);
             if (resizeRef.options?.cell && resizeRef.rectangle) {
                 const handleIndex = getIndexByResizeHandle(resizeRef.handle);
-                const { originPoint, handlePoint } = getResizeOriginPointAndHandlePoint(board, handleIndex, resizeRef.rectangle);
-                const resizePoints: [Point, Point] = [resizeState.startPoint, resizeState.endPoint];
-                const { xZoom, yZoom } = getResizeZoom(resizePoints, originPoint, handlePoint, false, false);
-                const originPoints = resizeRef.options.cell.points;
-                const targetPoints = originPoints.map((p) => {
-                    return movePointByZoomAndOriginPoint(p, originPoint, xZoom, yZoom);
-                }) as [Point, Point];
-
-                const originRect = RectangleClient.getRectangleByPoints(originPoints);
-                const targetRect = RectangleClient.getRectangleByPoints(targetPoints);
-                const offsetWidth = targetRect.width - originRect.width;
-                const offsetHeight = targetRect.height - originRect.height;
                 const edge = getResizeEdge(handleIndex);
-                if (offsetWidth !== 0 && edge) {
-                    const columnIndex = getResizeTargetRowOrColumnIndex(resizeRef.element, resizeRef.options.cell, edge, false);
-                    const width = getCurrentRowOrColumnSize(resizeRef.element, columnIndex, false) + offsetWidth;
-                    if (width >= MIN_CELL_SIZE) {
-                        const { columns, points } = updateColumns(
-                            resizeRef.element,
-                            resizeRef.element.columns[columnIndex].id,
-                            width,
-                            offsetWidth,
-                            edge
-                        );
-                        Transforms.setNode(board, { columns, points }, path);
+                if (edge) {
+                    const isRow = isRowResizeHandle(handleIndex);
+                    const pointerOffset = isRow
+                        ? resizeState.endPoint[1] - resizeState.startPoint[1]
+                        : resizeState.endPoint[0] - resizeState.startPoint[0];
+                    const targetIndex = getResizeTargetRowOrColumnIndex(resizeRef.element, resizeRef.options.cell, edge, isRow);
+                    if (targetIndex < 0) {
+                        return;
                     }
-                } else if (offsetHeight !== 0 && edge) {
-                    const rowIndex = getResizeTargetRowOrColumnIndex(resizeRef.element, resizeRef.options.cell, edge, true);
-                    const height = getCurrentRowOrColumnSize(resizeRef.element, rowIndex, true) + offsetHeight;
-                    if (height >= MIN_CELL_SIZE) {
-                        const { rows, points } = updateRows(
-                            resizeRef.element,
-                            resizeRef.element.rows[rowIndex].id,
-                            height,
-                            offsetHeight,
-                            edge
-                        );
-                        Transforms.setNode(board, { rows, points }, path);
+                    const currentSize = getCurrentRowOrColumnSize(resizeRef.element, targetIndex, isRow);
+                    const sizeOffset = edge === 'start' ? -pointerOffset : pointerOffset;
+                    const targetSize = Math.max(MIN_CELL_SIZE, currentSize + sizeOffset);
+                    const appliedOffset = targetSize - currentSize;
+                    if (appliedOffset !== 0) {
+                        if (isRow) {
+                            const { rows, points } = updateRows(
+                                resizeRef.element,
+                                resizeRef.element.rows[targetIndex].id,
+                                targetSize,
+                                appliedOffset,
+                                edge
+                            );
+                            Transforms.setNode(board, { rows, points }, path);
+                        } else {
+                            const { columns, points } = updateColumns(
+                                resizeRef.element,
+                                resizeRef.element.columns[targetIndex].id,
+                                targetSize,
+                                appliedOffset,
+                                edge
+                            );
+                            Transforms.setNode(board, { columns, points }, path);
+                        }
                     }
                 }
             } else if (isCornerHandle(board, resizeRef.handle)) {
@@ -162,6 +158,10 @@ export function withTableResize(board: PlaitTableBoard) {
     withResize<PlaitBaseTable, ResizeHandle, TableResizeOptions>(board, options);
 
     return board;
+}
+
+function isRowResizeHandle(handleIndex: number) {
+    return [Number(ResizeHandle.n), Number(ResizeHandle.s)].includes(handleIndex);
 }
 
 function scaleRowsOrColumns(data: { id: string; width?: number; height?: number }[], offset: number, originSize: number, isRow: boolean) {

--- a/packages/draw/src/plugins/with-table-resize.ts
+++ b/packages/draw/src/plugins/with-table-resize.ts
@@ -1,5 +1,5 @@
-import { PlaitBoard, Point, RectangleClient, Transforms, isSelectedElement, getSelectedElements, hasValidAngle } from '@plait/core';
-import { PlaitBaseTable, PlaitTableBoard, PlaitTableCellWithPoints } from '../interfaces/table';
+import { PlaitBoard, Point, RectangleClient, Transforms, getSelectedElements, hasValidAngle } from '@plait/core';
+import { PlaitBaseTable, PlaitTableBoard, PlaitTableCell, PlaitTableCellWithPoints } from '../interfaces/table';
 import {
     getIndexByResizeHandle,
     isCornerHandle,
@@ -11,7 +11,7 @@ import {
     WithResizeOptions,
     normalizeShapePoints
 } from '@plait/common';
-import { getCellsWithPoints, updateColumns, updateRows } from '../utils/table';
+import { getCellsWithPoints, getCurrentRowOrColumnSize, ResizeEdge, updateColumns, updateRows } from '../utils/table';
 import { getHitRectangleResizeHandleRef } from '../utils/position/geometry';
 import { getResizeOriginPointAndHandlePoint, getResizeZoom, movePointByZoomAndOriginPoint } from './with-draw-resize';
 import { getSnapResizingRef, getSnapResizingRefOptions } from '../utils/snap-resizing';
@@ -41,25 +41,10 @@ export function withTableResize(board: PlaitTableBoard) {
             const hitElement = selectedElements[0];
             // debugGenerator.clear();
             if (hitElement && PlaitDrawElement.isElementByTable(hitElement)) {
-                let rectangle = board.getRectangle(hitElement) as RectangleClient;
-                // debugGenerator.drawRectangle(board, rectangle);
-                // debugGenerator.drawCircles(board, [point], 5);
-                let handleRef = getHitRectangleResizeHandleRef(board, rectangle, point, hitElement.angle);
-                if (handleRef) {
-                    const selectElement = isSelectedElement(board, hitElement);
-                    if ((selectElement && isSingleSelectTable(board)) || (!selectElement && !isCornerHandle(board, handleRef.handle))) {
-                        return {
-                            element: hitElement,
-                            handle: handleRef.handle,
-                            cursorClass: handleRef.cursorClass,
-                            rectangle
-                        };
-                    }
-                }
                 const cells = getCellsWithPoints(board, hitElement);
                 for (let i = 0; i < cells.length; i++) {
-                    rectangle = RectangleClient.getRectangleByPoints(cells[i].points);
-                    handleRef = getHitRectangleResizeHandleRef(board, rectangle, point, 0);
+                    const rectangle = RectangleClient.getRectangleByPoints(cells[i].points);
+                    const handleRef = getHitRectangleResizeHandleRef(board, rectangle, point, 0);
                     if (handleRef && !isCornerHandle(board, handleRef.handle)) {
                         return {
                             element: hitElement,
@@ -72,6 +57,19 @@ export function withTableResize(board: PlaitTableBoard) {
                         };
                     }
                 }
+
+                const rectangle = board.getRectangle(hitElement) as RectangleClient;
+                // debugGenerator.drawRectangle(board, rectangle);
+                // debugGenerator.drawCircles(board, [point], 5);
+                const handleRef = getHitRectangleResizeHandleRef(board, rectangle, point, hitElement.angle);
+                if (handleRef && isCornerHandle(board, handleRef.handle)) {
+                    return {
+                        element: hitElement,
+                        handle: handleRef.handle,
+                        cursorClass: handleRef.cursorClass,
+                        rectangle
+                    };
+                }
             }
             return null;
         },
@@ -80,26 +78,47 @@ export function withTableResize(board: PlaitTableBoard) {
             const path = PlaitBoard.findPath(board, resizeRef.element);
             if (resizeRef.options?.cell && resizeRef.rectangle) {
                 const handleIndex = getIndexByResizeHandle(resizeRef.handle);
-                const { originPoint, handlePoint } = getResizeOriginPointAndHandlePoint(board, handleIndex, resizeRef.rectangle!);
+                const { originPoint, handlePoint } = getResizeOriginPointAndHandlePoint(board, handleIndex, resizeRef.rectangle);
                 const resizePoints: [Point, Point] = [resizeState.startPoint, resizeState.endPoint];
                 const { xZoom, yZoom } = getResizeZoom(resizePoints, originPoint, handlePoint, false, false);
-                const originPoints = resizeRef.options?.cell.points;
+                const originPoints = resizeRef.options.cell.points;
                 const targetPoints = originPoints.map((p) => {
                     return movePointByZoomAndOriginPoint(p, originPoint, xZoom, yZoom);
                 }) as [Point, Point];
-                const offsetX = targetPoints[1][0] - originPoints[1][0];
-                const offsetY = targetPoints[1][1] - originPoints[1][1];
-                const width = targetPoints[1][0] - targetPoints[0][0];
-                const height = targetPoints[1][1] - targetPoints[0][1];
-                if (offsetX !== 0 && width >= MIN_CELL_SIZE) {
-                    const { columns, points } = updateColumns(resizeRef.element, resizeRef.options?.cell.columnId, width, offsetX);
-                    Transforms.setNode(board, { columns, points }, path);
-                } else if (offsetY !== 0 && height >= MIN_CELL_SIZE) {
-                    const { rows, points } = updateRows(resizeRef.element, resizeRef.options?.cell.rowId, height, offsetY);
-                    Transforms.setNode(board, { rows, points }, path);
+
+                const originRect = RectangleClient.getRectangleByPoints(originPoints);
+                const targetRect = RectangleClient.getRectangleByPoints(targetPoints);
+                const offsetWidth = targetRect.width - originRect.width;
+                const offsetHeight = targetRect.height - originRect.height;
+                const edge = getResizeEdge(handleIndex);
+                if (offsetWidth !== 0 && edge) {
+                    const columnIndex = getResizeTargetRowOrColumnIndex(resizeRef.element, resizeRef.options.cell, edge, false);
+                    const width = getCurrentRowOrColumnSize(resizeRef.element, columnIndex, false) + offsetWidth;
+                    if (width >= MIN_CELL_SIZE) {
+                        const { columns, points } = updateColumns(
+                            resizeRef.element,
+                            resizeRef.element.columns[columnIndex].id,
+                            width,
+                            offsetWidth,
+                            edge
+                        );
+                        Transforms.setNode(board, { columns, points }, path);
+                    }
+                } else if (offsetHeight !== 0 && edge) {
+                    const rowIndex = getResizeTargetRowOrColumnIndex(resizeRef.element, resizeRef.options.cell, edge, true);
+                    const height = getCurrentRowOrColumnSize(resizeRef.element, rowIndex, true) + offsetHeight;
+                    if (height >= MIN_CELL_SIZE) {
+                        const { rows, points } = updateRows(
+                            resizeRef.element,
+                            resizeRef.element.rows[rowIndex].id,
+                            height,
+                            offsetHeight,
+                            edge
+                        );
+                        Transforms.setNode(board, { rows, points }, path);
+                    }
                 }
-            } else {
-                const isFromCorner = isCornerHandle(board, resizeRef.handle);
+            } else if (isCornerHandle(board, resizeRef.handle)) {
                 const isAspectRatio = resizeState.isShift;
                 const handleIndex = getIndexByResizeHandle(resizeRef.handle);
                 const { originPoint, handlePoint } = getResizeOriginPointAndHandlePoint(board, handleIndex, resizeRef.rectangle!);
@@ -112,7 +131,7 @@ export function withTableResize(board: PlaitTableBoard) {
                         handlePoint
                     },
                     isAspectRatio,
-                    isFromCorner
+                    true
                 );
                 const resizeSnapRef = getSnapResizingRef(board, [resizeRef.element], resizeSnapRefOptions);
                 snapG = resizeSnapRef.snapG;
@@ -126,26 +145,10 @@ export function withTableResize(board: PlaitTableBoard) {
                 let columns = [...resizeRef.element.columns];
                 let rows = [...resizeRef.element.rows];
                 if (offsetWidth !== 0) {
-                    columns = columns.map((item) => {
-                        if (item.width) {
-                            return {
-                                ...item,
-                                width: item.width + offsetWidth * (item.width / originRect.width)
-                            };
-                        }
-                        return item;
-                    });
+                    columns = scaleRowsOrColumns(columns, offsetWidth, originRect.width, false);
                 }
                 if (offsetHeight !== 0) {
-                    rows = rows.map((item) => {
-                        if (item.height) {
-                            return {
-                                ...item,
-                                height: item.height + offsetHeight * (item.height / originRect.height)
-                            };
-                        }
-                        return item;
-                    });
+                    rows = scaleRowsOrColumns(rows, offsetHeight, originRect.height, true);
                 }
                 Transforms.setNode(board, { points: normalizeShapePoints(points), columns, rows }, path);
             }
@@ -159,4 +162,38 @@ export function withTableResize(board: PlaitTableBoard) {
     withResize<PlaitBaseTable, ResizeHandle, TableResizeOptions>(board, options);
 
     return board;
+}
+
+function scaleRowsOrColumns(data: { id: string; width?: number; height?: number }[], offset: number, originSize: number, isRow: boolean) {
+    const dimension = isRow ? 'height' : 'width';
+    return data.map((item) => {
+        if (item[dimension]) {
+            return {
+                ...item,
+                [dimension]: item[dimension]! + offset * (item[dimension]! / originSize)
+            };
+        }
+        return item;
+    });
+}
+
+function getResizeEdge(handleIndex: number): ResizeEdge | undefined {
+    if ([Number(ResizeHandle.s), Number(ResizeHandle.e)].includes(handleIndex)) {
+        return 'end';
+    }
+    if ([Number(ResizeHandle.n), Number(ResizeHandle.w)].includes(handleIndex)) {
+        return 'start';
+    }
+    return undefined;
+}
+
+function getResizeTargetRowOrColumnIndex(element: PlaitBaseTable, resizeCell: PlaitTableCell, edge: ResizeEdge, isRow: boolean) {
+    const data = isRow ? element.rows : element.columns;
+    const id = isRow ? resizeCell.rowId : resizeCell.columnId;
+    const span = isRow ? resizeCell.rowspan : resizeCell.colspan;
+    let index = data.findIndex((item) => item.id === id);
+    if (edge === 'end' && span && span !== 1) {
+        index += span - 1;
+    }
+    return index;
 }

--- a/packages/draw/src/utils/position/geometry.ts
+++ b/packages/draw/src/utils/position/geometry.ts
@@ -5,7 +5,8 @@ import {
     getRotatedResizeCursorClassByAngle,
     ROTATE_HANDLE_SIZE,
     ROTATE_HANDLE_DISTANCE_TO_ELEMENT,
-    ResizeHandle
+    ResizeHandle,
+    isEdgeHandle
 } from '@plait/common';
 
 export interface ResizeHandleRef {
@@ -18,10 +19,14 @@ export const getHitRectangleResizeHandleRef = (
     board: PlaitBoard,
     rectangle: RectangleClient,
     point: Point,
-    angle: number = 0
+    angle: number = 0,
+    isEdgeHandleOnly: boolean = false
 ): ResizeHandleRef | undefined => {
     const centerPoint = RectangleClient.getCenterPoint(rectangle);
-    const resizeHandleRefs = getRectangleResizeHandleRefs(rectangle, RESIZE_HANDLE_DIAMETER);
+    let resizeHandleRefs = getRectangleResizeHandleRefs(rectangle, RESIZE_HANDLE_DIAMETER);
+    if (isEdgeHandleOnly) {
+        resizeHandleRefs = resizeHandleRefs.filter((resizeHandleRef) => isEdgeHandle(board, resizeHandleRef.handle));
+    }
     if (angle) {
         const rotatedPoint = rotatePoints([point], centerPoint, -angle)[0];
         let result = resizeHandleRefs.find((resizeHandleRef) => {

--- a/packages/draw/src/utils/table.ts
+++ b/packages/draw/src/utils/table.ts
@@ -116,15 +116,30 @@ export function getTextManageByCell(board: PlaitBoard, cell: PlaitTableCell) {
     return getTextManage(board, undefined, cell);
 }
 
-export const updateColumns = (table: PlaitBaseTable, columnId: string, width: number, offset: number) => {
+export type ResizeEdge = 'start' | 'end';
+
+export function getCurrentRowOrColumnSize(table: PlaitBaseTable, index: number, isRow: boolean) {
+    const rectangle = RectangleClient.getRectangleByPoints(table.points);
+    const data = isRow ? table.rows : table.columns;
+    const sizes = calculateCellsSize(data, isRow ? rectangle.height : rectangle.width, data.length, !isRow);
+    return sizes[index] || 0;
+}
+
+export const updateColumns = (table: PlaitBaseTable, columnId: string, width: number, offset: number, edge: ResizeEdge = 'end') => {
     const columns = table.columns.map((item) => (item.id === columnId ? { ...item, width } : item));
-    const points = [table.points[0], [table.points[1][0] + offset, table.points[1][1]]] as Point[];
+    let points = [table.points[0], [table.points[1][0] + offset, table.points[1][1]]] as Point[];
+    if (edge === 'start') {
+        points = [[table.points[0][0] - offset, table.points[0][1]], table.points[1]] as Point[];
+    }
     return { columns, points };
 };
 
-export const updateRows = (table: PlaitBaseTable, rowId: string, height: number, offset: number) => {
+export const updateRows = (table: PlaitBaseTable, rowId: string, height: number, offset: number, edge: ResizeEdge = 'end') => {
     const rows = table.rows.map((item) => (item.id === rowId ? { ...item, height } : item));
-    const points = [table.points[0], [table.points[1][0], table.points[1][1] + offset]] as Point[];
+    let points = [table.points[0], [table.points[1][0], table.points[1][1] + offset]] as Point[];
+    if (edge === 'start') {
+        points = [[table.points[0][0], table.points[0][1] - offset], table.points[1]] as Point[];
+    }
     return { rows, points };
 };
 


### PR DESCRIPTION
## Summary

This PR reworks the table resize interaction from the older #931 idea against the current `develop` branch.

The important behavior change is not just a code cleanup. It makes table resize intent explicit:

```text
cell side edge -> resize the corresponding row/column
table corner -> resize the whole table
cell start edge -> resize the row/column from the start side
cell end edge -> resize the row/column from the end side
merged-cell start edge -> resize the first covered row/column
merged-cell end edge -> resize the last covered row/column
```

## Interaction Intent Changes

### 1. Outer table edges now mean row/column resize, not whole-table resize

Before this change, when a user selected a table and moved the pointer to the right edge of the table, that position could match both:

- the table right resize handle
- the last cell right resize handle

The old hit-test path checked the table handle first, so the interaction was often interpreted as whole-table resize.

That meant the user appeared to be dragging the last column edge, but the system treated it as resizing the whole table.

After this change, cell resize handles are checked first. If the pointer hits the right edge of the last cell, the interaction is handled as a column resize.

```text
Before: drag table right edge -> resize the whole table
After:  drag table right edge -> resize the last column
```

### 2. Whole-table resize is now reserved for table corners

Before this change, both table side handles and table corner handles could trigger whole-table resize.

That made these two user intents compete with each other:

- resizing a row/column
- resizing the whole table

After this change, table-level resize only falls back to corner handles. Side edges are reserved for row/column resize.

```text
Side edge -> row/column resize
Corner    -> whole-table resize
```

This makes the interaction model mutually exclusive and easier to predict.

### 3. Start-side row/column resize is now explicit

The previous implementation could already move `points[0]` through the table-level resize path. For example, when the interaction was handled as a whole-table resize, `resizeSnapRef.activePoints` plus `normalizeShapePoints` could produce a new start point.

The gap was in the cell row/column resize path. The old row/column update helpers behaved like end-side updates:

```text
column width changes -> update points[1][0]
row height changes   -> update points[1][1]
```

That is correct for right/bottom cell edges, but it does not clearly model the user intent when dragging a left/top cell edge.

When a user drags the left edge of the first column, the expected intent is not whole-table resize. The intent is:

```text
move the table left boundary and resize the first column
```

So the row/column resize path itself needs to know whether the dragged edge is the start side or the end side.

This PR introduces a small `ResizeEdge` concept:

- `w / n` -> `start`
- `e / s` -> `end`

So the row/column update now matches the dragged cell edge:

```text
left cell edge   -> update points[0][0] while resizing the target column
right cell edge  -> update points[1][0] while resizing the target column
top cell edge    -> update points[0][1] while resizing the target row
bottom cell edge -> update points[1][1] while resizing the target row
```

The improvement is therefore not first-time support for changing `points[0]`; it is making start-side row/column resize explicit instead of relying on the table-level resize path.

### 4. Merged cells resolve the resize target by dragged edge

Merged cells can cover multiple rows or columns.

For example, a cell with `colspan=3` covers columns 1, 2, and 3.

The expected interaction is:

```text
drag the left edge  -> resize column 1
drag the right edge -> resize column 3
```

The old logic mainly followed the cell starting `rowId` / `columnId`, which made end-side resize ambiguous for `rowspan` / `colspan` cells.

This PR resolves the target row/column from the dragged edge:

```text
start edge -> first row/column covered by the cell
end edge   -> last row/column covered by the cell span
```

So merged-cell resize now maps to the user visible drag target instead of always leaning on the cell starting row/column.

## Implementation Notes

- `hitTest` checks cell side handles before table-level handles.
- table-level fallback only accepts corner handles.
- `ResizeEdge` represents whether the dragged cell edge is the start or end side.
- `getResizeTargetRowOrColumnIndex` resolves the row/column affected by normal and merged cells.
- `getCurrentRowOrColumnSize` derives the current rendered row/column size from the table layout, avoiding fragile inference from cell rectangles.

## Verification

- `npm run build:draw`

Focused manual checks to run:

- Resize the right/bottom edge of a normal table cell and verify only the target column/row is updated.
- Resize the left/top cell edge and verify the target row/column resizes from the start side.
- Resize a table corner and verify whole-table resize still works.
- Resize the start/end edge of a merged cell and verify the first/last covered row or column is updated.

Unit tests can be added in a follow-up once the interaction behavior is confirmed.