### PR TITLE
fix(core): refresh selection bounding in hand mode

### DIFF
--- a/.changeset/calm-hands-wave.md
+++ b/.changeset/calm-hands-wave.md
@@ -1,0 +1,5 @@
+---
+'@plait/core': patch
+---
+
+refresh the multi-selection rectangle while panning in hand mode

--- a/packages/core/src/plugins/with-selection.spec.ts
+++ b/packages/core/src/plugins/with-selection.spec.ts
@@ -1,0 +1,71 @@
+import { fakeAsync, tick } from '@angular/core/testing';
+import { PlaitBoard, PlaitElement, PlaitPointerType } from '../interfaces';
+import { clearNodeWeakMap, createTestingBoard, fakeNodeWeakMap } from '../testing';
+import { Transforms } from '../transforms';
+import { BOARD_TO_ELEMENT_HOST, cacheSelectedElements, getSelectedElements } from '../utils';
+import { withOptions } from './with-options';
+import { withSelection } from './with-selection';
+
+const children: PlaitElement[] = [
+    { id: 'first', type: 'geometry' },
+    { id: 'second', type: 'geometry' }
+];
+
+const createG = () => document.createElementNS('http://www.w3.org/2000/svg', 'g');
+
+describe('withSelection', () => {
+    let board: PlaitBoard;
+    let activeHost: SVGGElement;
+    let drawSelectionRectangle: jasmine.Spy;
+
+    beforeEach(() => {
+        board = createTestingBoard([withOptions, withSelection], children);
+        fakeNodeWeakMap(board);
+        activeHost = createG();
+        BOARD_TO_ELEMENT_HOST.set(board, {
+            lowerHost: createG(),
+            host: createG(),
+            upperHost: createG(),
+            topHost: createG(),
+            activeHost,
+            container: document.createElement('div'),
+            viewportContainer: document.createElement('div')
+        });
+        drawSelectionRectangle = jasmine.createSpy('drawSelectionRectangle').and.callFake(() => createG());
+        board.drawSelectionRectangle = drawSelectionRectangle;
+    });
+
+    afterEach(() => {
+        clearNodeWeakMap(board);
+        BOARD_TO_ELEMENT_HOST.delete(board);
+    });
+
+    it('should refresh the multi-selection rectangle after viewport changes in hand mode', fakeAsync(() => {
+        cacheSelectedElements(board, children);
+        board.afterChange();
+        const initialRectangle = activeHost.firstElementChild;
+        expect(activeHost.contains(initialRectangle)).toBeTrue();
+
+        board.pointer = PlaitPointerType.hand;
+        Transforms.setViewport(board, { zoom: 1, origination: [10, 10] });
+        tick();
+
+        expect(drawSelectionRectangle).toHaveBeenCalledTimes(2);
+        expect(activeHost.contains(initialRectangle)).toBeFalse();
+        expect(activeHost.children.length).toBe(1);
+        expect(activeHost.firstElementChild).not.toBe(initialRectangle);
+    }));
+
+    it('should not update selected elements from selection operations in hand mode', fakeAsync(() => {
+        cacheSelectedElements(board, children);
+        board.pointer = PlaitPointerType.hand;
+
+        Transforms.setSelection(board, {
+            anchor: [100, 100],
+            focus: [100, 100]
+        });
+        tick();
+
+        expect(getSelectedElements(board)).toEqual(children);
+    }));
+});

--- a/packages/core/src/plugins/with-selection.ts
+++ b/packages/core/src/plugins/with-selection.ts
@@ -185,7 +185,7 @@ export function withSelection(board: PlaitBoard) {
                 removeSelectedElement(board, op.node, true);
             }
         });
-        if (isHandleSelection(board) && hasSetSelectionOperation(board)) {
+        if (!PlaitBoard.isPointer(board, PlaitPointerType.hand) && isHandleSelection(board) && hasSetSelectionOperation(board)) {
             try {
                 if (!isShift) {
                     selectionRectangleG?.remove();

--- a/packages/core/src/utils/selection.ts
+++ b/packages/core/src/utils/selection.ts
@@ -5,7 +5,6 @@ import {
     PlaitGroup,
     PlaitOperation,
     PlaitPluginKey,
-    PlaitPointerType,
     Point,
     RectangleClient,
     SELECTION_BORDER_COLOR,
@@ -41,7 +40,7 @@ export function clearSelectionMoving(board: PlaitBoard) {
 
 export function isHandleSelection(board: PlaitBoard) {
     const options = getSelectionOptions(board);
-    return board.pointer !== PlaitPointerType.hand && !options.isDisabledSelection && !PlaitBoard.isReadonly(board);
+    return !options.isDisabledSelection && !PlaitBoard.isReadonly(board);
 }
 
 export function hasSetSelectionOperation(board: PlaitBoard) {


### PR DESCRIPTION
Following your suggestion in plait-board/drawnix#448, this moves the hand-pointer check to the selection-operation path so the existing multi-selection bounds can still refresh after viewport changes.

Fixes plait-board/drawnix#394.

Tests:
- `npx ng test core --watch=false --progress=false --browsers=ChromeHeadlessCI`
- `npm run build:core`
