### PR TITLE
fix(core): isolate Space panning from active tools

### DIFF
--- a/.changeset/warm-spaces-wave.md
+++ b/.changeset/warm-spaces-wave.md
@@ -1,0 +1,6 @@
+---
+'@plait/core': patch
+'@plait/draw': patch
+---
+
+prevent active tools from handling Space panning gestures

--- a/packages/core/src/interfaces/board.ts
+++ b/packages/core/src/interfaces/board.ts
@@ -12,6 +12,7 @@ import {
     BOARD_TO_MOVING_POINT,
     BOARD_TO_MOVING_POINT_IN_BOARD,
     BOARD_TO_ROUGH_SVG,
+    BOARD_TO_TEMPORARY_POINTER,
     IS_BOARD_ALIVE,
     IS_BOARD_CACHE,
     IS_TEXT_EDITABLE,
@@ -193,13 +194,13 @@ export const PlaitBoard = {
         return !!IS_TEXT_EDITABLE.get(board);
     },
     getPointer<T = PlaitPointerType>(board: PlaitBoard) {
-        return board.pointer as T;
+        return (BOARD_TO_TEMPORARY_POINTER.get(board) ?? board.pointer) as T;
     },
     isPointer<T = PlaitPointerType>(board: PlaitBoard, pointer: T) {
-        return board.pointer === pointer;
+        return PlaitBoard.getPointer(board) === pointer;
     },
     isInPointer<T = PlaitPointerType>(board: PlaitBoard, pointers: T[]) {
-        const point = board.pointer as T;
+        const point = PlaitBoard.getPointer<T>(board);
         return pointers.includes(point);
     },
     getMovingPointInBoard(board: PlaitBoard) {

--- a/packages/core/src/plugins/with-hand.spec.ts
+++ b/packages/core/src/plugins/with-hand.spec.ts
@@ -93,6 +93,33 @@ describe('withHandPointer', () => {
         expect(PlaitBoard.getPointer(board)).toBe(customPointer);
     });
 
+    it('restores the selected pointer after a Space hand gesture is cancelled', () => {
+        const customPointer = 'custom-draw';
+        const innerPointerCancel = jasmine.createSpy('innerPointerCancel').and.callFake(() => {
+            expect(PlaitBoard.getPointer(board)).toBe(PlaitPointerType.hand);
+        });
+        const withInnerPointerCancel = (board: PlaitBoard) => {
+            board.pointerCancel = innerPointerCancel;
+            return board;
+        };
+        board = createTestingBoard([withOptions, withInnerPointerCancel, withHandPointer], []);
+        fakeBoardElementHost(board);
+        board.pointer = customPointer;
+
+        board.keyDown(createSpaceEvent('keydown'));
+        board.pointerDown(createPointerEvent('pointerdown', 100, 50));
+        board.keyUp(createSpaceEvent('keyup'));
+
+        expect(PlaitBoard.getPointer(board)).toBe(PlaitPointerType.hand);
+
+        const pointerCancelEvent = createPointerEvent('pointercancel', 100, 50);
+        board.pointerCancel(pointerCancelEvent);
+
+        expect(innerPointerCancel).toHaveBeenCalledOnceWith(pointerCancelEvent);
+        expect(board.pointer).toBe(customPointer);
+        expect(PlaitBoard.getPointer(board)).toBe(customPointer);
+    });
+
     it('does not interrupt an active pointer interaction when Space is pressed', () => {
         const customPointer = 'custom-draw';
         const interactionComplete = jasmine.createSpy('interactionComplete');

--- a/packages/core/src/plugins/with-hand.spec.ts
+++ b/packages/core/src/plugins/with-hand.spec.ts
@@ -1,8 +1,10 @@
 import { fakeAsync, tick } from '@angular/core/testing';
+import { SPACE } from '../constants';
 import { PlaitBoard, PlaitElement, PlaitPointerType } from '../interfaces';
 import {
     clearBoardElementHost,
     clearNodeWeakMap,
+    createKeyboardEvent,
     createPointerEvent,
     createTestingBoard,
     fakeBoardElementHost,
@@ -20,12 +22,7 @@ const children: PlaitElement[] = [
 ];
 
 const createSpaceEvent = (type: 'keydown' | 'keyup') => {
-    return new KeyboardEvent(type, {
-        code: 'Space',
-        key: ' ',
-        bubbles: true,
-        cancelable: true
-    });
+    return createKeyboardEvent(type, SPACE, ' ', {}, 'Space');
 };
 
 describe('withHandPointer', () => {

--- a/packages/core/src/plugins/with-hand.spec.ts
+++ b/packages/core/src/plugins/with-hand.spec.ts
@@ -1,0 +1,157 @@
+import { fakeAsync, tick } from '@angular/core/testing';
+import { PlaitBoard, PlaitElement, PlaitPointerType } from '../interfaces';
+import {
+    clearBoardElementHost,
+    clearNodeWeakMap,
+    createPointerEvent,
+    createTestingBoard,
+    fakeBoardElementHost,
+    fakeNodeWeakMap
+} from '../testing';
+import { Transforms } from '../transforms';
+import { cacheSelectedElements, createG, getSelectedElements } from '../utils';
+import { withHandPointer } from './with-hand';
+import { withOptions } from './with-options';
+import { withSelection } from './with-selection';
+
+const children: PlaitElement[] = [
+    { id: 'first', type: 'geometry' },
+    { id: 'second', type: 'geometry' }
+];
+
+const createSpaceEvent = (type: 'keydown' | 'keyup') => {
+    return new KeyboardEvent(type, {
+        code: 'Space',
+        key: ' ',
+        bubbles: true,
+        cancelable: true
+    });
+};
+
+describe('withHandPointer', () => {
+    let board: PlaitBoard;
+
+    afterEach(() => {
+        clearNodeWeakMap(board);
+        clearBoardElementHost(board);
+    });
+
+    it('exposes Space panning as hand mode without changing the selected pointer', () => {
+        const customPointer = 'custom-draw';
+        const interactionDown = jasmine.createSpy('interactionDown');
+        const interactionMove = jasmine.createSpy('interactionMove');
+        const innerPointerUp = jasmine.createSpy('innerPointerUp');
+        const withInnerPointerUp = (board: PlaitBoard) => {
+            board.pointerUp = innerPointerUp;
+            return board;
+        };
+        const withPointerInteraction = (board: PlaitBoard) => {
+            const { pointerDown, pointerMove } = board;
+            let isInteracting = false;
+            board.pointerDown = (event) => {
+                if (PlaitBoard.isInPointer(board, [customPointer])) {
+                    isInteracting = true;
+                    interactionDown();
+                }
+                pointerDown(event);
+            };
+            board.pointerMove = (event) => {
+                if (isInteracting) {
+                    interactionMove();
+                }
+                pointerMove(event);
+            };
+            return board;
+        };
+        board = createTestingBoard([withOptions, withInnerPointerUp, withHandPointer, withPointerInteraction], []);
+        const { viewportContainer } = fakeBoardElementHost(board);
+        Object.defineProperty(viewportContainer, 'scrollLeft', { value: 200, writable: true });
+        Object.defineProperty(viewportContainer, 'scrollTop', { value: 100, writable: true });
+        board.pointer = customPointer;
+
+        board.keyDown(createSpaceEvent('keydown'));
+
+        expect(board.pointer).toBe(customPointer);
+        expect(PlaitBoard.getPointer(board)).toBe(PlaitPointerType.hand);
+        expect(PlaitBoard.isPointer(board, PlaitPointerType.hand)).toBeTrue();
+        expect(PlaitBoard.isInPointer(board, [PlaitPointerType.hand])).toBeTrue();
+
+        board.pointerDown(createPointerEvent('pointerdown', 100, 50));
+        board.keyUp(createSpaceEvent('keyup'));
+
+        expect(PlaitBoard.getPointer(board)).toBe(PlaitPointerType.hand);
+
+        board.pointerMove(createPointerEvent('pointermove', 120, 60));
+        board.pointerUp(createPointerEvent('pointerup', 120, 60));
+
+        expect(interactionDown).not.toHaveBeenCalled();
+        expect(interactionMove).not.toHaveBeenCalled();
+        expect(innerPointerUp).not.toHaveBeenCalled();
+        expect(viewportContainer.scrollLeft).toBe(180);
+        expect(viewportContainer.scrollTop).toBe(90);
+
+        board.globalPointerUp(createPointerEvent('pointerup', 120, 60));
+
+        expect(board.pointer).toBe(customPointer);
+        expect(PlaitBoard.getPointer(board)).toBe(customPointer);
+    });
+
+    it('does not interrupt an active pointer interaction when Space is pressed', () => {
+        const customPointer = 'custom-draw';
+        const interactionComplete = jasmine.createSpy('interactionComplete');
+        const withPointerInteraction = (board: PlaitBoard) => {
+            const { pointerDown, pointerUp } = board;
+            let isInteracting = false;
+            board.pointerDown = (event) => {
+                if (PlaitBoard.isPointer(board, customPointer)) {
+                    isInteracting = true;
+                }
+                pointerDown(event);
+            };
+            board.pointerUp = (event) => {
+                if (isInteracting && PlaitBoard.isPointer(board, customPointer)) {
+                    isInteracting = false;
+                    interactionComplete();
+                }
+                pointerUp(event);
+            };
+            return board;
+        };
+        board = createTestingBoard([withOptions, withHandPointer, withPointerInteraction], []);
+        fakeBoardElementHost(board);
+        board.pointer = customPointer;
+
+        board.pointerDown(createPointerEvent('pointerdown', 100, 50));
+        board.keyDown(createSpaceEvent('keydown'));
+
+        expect(PlaitBoard.getPointer(board)).toBe(customPointer);
+
+        board.pointerUp(createPointerEvent('pointerup', 120, 60));
+        board.globalPointerUp(createPointerEvent('pointerup', 120, 60));
+        board.keyUp(createSpaceEvent('keyup'));
+
+        expect(interactionComplete).toHaveBeenCalledOnceWith();
+    });
+
+    it('preserves the selection overlay while panning with Space', fakeAsync(() => {
+        board = createTestingBoard([withOptions, withSelection, withHandPointer], children);
+        fakeNodeWeakMap(board);
+        const { activeHost } = fakeBoardElementHost(board);
+        const drawSelectionRectangle = jasmine.createSpy('drawSelectionRectangle').and.callFake(() => createG());
+        board.drawSelectionRectangle = drawSelectionRectangle;
+        cacheSelectedElements(board, children);
+        board.afterChange();
+        const initialRectangle = activeHost.firstElementChild;
+
+        board.keyDown(createSpaceEvent('keydown'));
+        Transforms.setViewport(board, { zoom: 1, origination: [10, 10] });
+        tick();
+
+        expect(getSelectedElements(board)).toEqual(children);
+        expect(drawSelectionRectangle).toHaveBeenCalledTimes(2);
+        expect(activeHost.contains(initialRectangle)).toBeFalse();
+        expect(activeHost.children.length).toBe(1);
+
+        board.keyUp(createSpaceEvent('keyup'));
+    }));
+});

--- a/packages/core/src/plugins/with-hand.ts
+++ b/packages/core/src/plugins/with-hand.ts
@@ -29,7 +29,7 @@ export function withHandPointer<T extends PlaitBoard>(board: T) {
     let hasWheelPressed = false;
     let hasSecondaryPressed = false;
     let isShortcutKeyPressed = false;
-    let isShortcutPointerDown = false;
+    let isSpaceHandGestureActive = false;
     let isMainPointerPressed = false;
 
     board.pointerDown = (event: PointerEvent) => {
@@ -39,7 +39,7 @@ export function withHandPointer<T extends PlaitBoard>(board: T) {
         const options = (board as unknown as PlaitOptionsBoard).getPluginOptions<WithHandPluginOptions>(PlaitPluginKey.withHand);
         const canEnterHandMode = options?.isHandMode(board, event) || PlaitBoard.isPointer(board, PlaitPointerType.hand);
         if (canEnterHandMode && isMainPointer(event)) {
-            isShortcutPointerDown = BOARD_TO_TEMPORARY_POINTER.has(board);
+            isSpaceHandGestureActive = BOARD_TO_TEMPORARY_POINTER.has(board);
             movingPoint = {
                 x: event.x,
                 y: event.y
@@ -108,38 +108,22 @@ export function withHandPointer<T extends PlaitBoard>(board: T) {
 
     board.pointerUp = (event: PointerEvent) => {
         isMainPointerPressed = false;
-        if (isHandMoving || isShortcutPointerDown) {
+        if (isHandMoving || isSpaceHandGestureActive) {
             return;
         }
         pointerUp(event);
     };
 
     board.globalPointerUp = (event: PointerEvent) => {
-        isMainPointerPressed = false;
-        if (movingPoint) {
-            movingPoint = null;
-        }
-        exitHandMode();
-        hasWheelPressed = false;
-        hasSecondaryPressed = false;
+        finishHandGesture();
         globalPointerUp(event);
-        isShortcutPointerDown = false;
-        if (!isShortcutKeyPressed) {
-            BOARD_TO_TEMPORARY_POINTER.delete(board);
-        }
+        clearTemporaryHandIfIdle();
     };
 
     board.pointerCancel = (event: PointerEvent) => {
         pointerCancel(event);
-        isMainPointerPressed = false;
-        movingPoint = null;
-        exitHandMode();
-        hasWheelPressed = false;
-        hasSecondaryPressed = false;
-        isShortcutPointerDown = false;
-        if (!isShortcutKeyPressed) {
-            BOARD_TO_TEMPORARY_POINTER.delete(board);
-        }
+        finishHandGesture();
+        clearTemporaryHandIfIdle();
     };
 
     board.keyDown = (event: KeyboardEvent) => {
@@ -157,10 +141,7 @@ export function withHandPointer<T extends PlaitBoard>(board: T) {
     board.keyUp = (event: KeyboardEvent) => {
         if (event.code === ShortcutKey) {
             isShortcutKeyPressed = false;
-            if (!isShortcutPointerDown) {
-                BOARD_TO_TEMPORARY_POINTER.delete(board);
-                PlaitBoard.getBoardContainer(board).classList.remove('viewport-moving');
-            }
+            clearTemporaryHandIfIdle();
         }
         keyUp(event);
     };
@@ -177,6 +158,22 @@ export function withHandPointer<T extends PlaitBoard>(board: T) {
         setTimeout(() => {
             IS_HAND_MODE.set(board, false);
         }, 0);
+    };
+
+    const finishHandGesture = () => {
+        isMainPointerPressed = false;
+        movingPoint = null;
+        exitHandMode();
+        hasWheelPressed = false;
+        hasSecondaryPressed = false;
+        isSpaceHandGestureActive = false;
+    };
+
+    const clearTemporaryHandIfIdle = () => {
+        if (!isShortcutKeyPressed && !isSpaceHandGestureActive) {
+            BOARD_TO_TEMPORARY_POINTER.delete(board);
+            PlaitBoard.getBoardContainer(board).classList.remove('viewport-moving');
+        }
     };
 
     return board;

--- a/packages/core/src/plugins/with-hand.ts
+++ b/packages/core/src/plugins/with-hand.ts
@@ -1,10 +1,10 @@
 import { DRAG_SELECTION_PRESS_AND_MOVE_BUFFER } from '../constants';
 import { PlaitPointerType, PlaitBoard, PlaitBoardMove, WithHandPluginOptions, PlaitPluginKey } from '../interfaces';
 import {
+    BOARD_TO_TEMPORARY_POINTER,
     distanceBetweenPointAndPoint,
     isMovingElements,
     isSelectionMoving,
-    setSelectionOptions,
     toHostPoint,
     toViewBoxPoint
 } from '../utils';
@@ -22,24 +22,29 @@ export const isHandMode = (board: PlaitBoard) => {
 };
 
 export function withHandPointer<T extends PlaitBoard>(board: T) {
-    const { pointerDown, pointerMove, globalPointerUp, keyDown, keyUp, pointerUp } = board;
+    const { pointerDown, pointerMove, pointerCancel, globalPointerUp, keyDown, keyUp, pointerUp } = board;
     let isHandMoving: boolean = false;
     let movingPoint: PlaitBoardMove | null = null;
     let pointerDownEvent: PointerEvent | null = null;
     let hasWheelPressed = false;
     let hasSecondaryPressed = false;
-    let beingPressedShortcutKey = false;
+    let isShortcutKeyPressed = false;
+    let isShortcutPointerDown = false;
+    let isMainPointerPressed = false;
 
     board.pointerDown = (event: PointerEvent) => {
+        if (isMainPointer(event)) {
+            isMainPointerPressed = true;
+        }
         const options = (board as unknown as PlaitOptionsBoard).getPluginOptions<WithHandPluginOptions>(PlaitPluginKey.withHand);
-        const canEnterHandMode =
-            options?.isHandMode(board, event) || PlaitBoard.isPointer(board, PlaitPointerType.hand) || beingPressedShortcutKey;
+        const canEnterHandMode = options?.isHandMode(board, event) || PlaitBoard.isPointer(board, PlaitPointerType.hand);
         if (canEnterHandMode && isMainPointer(event)) {
+            isShortcutPointerDown = BOARD_TO_TEMPORARY_POINTER.has(board);
             movingPoint = {
                 x: event.x,
                 y: event.y
             };
-            if (!PlaitBoard.isPointer(board, PlaitPointerType.hand)) {
+            if (board.pointer !== PlaitPointerType.hand) {
                 PlaitBoard.getBoardContainer(board).classList.add('viewport-moving');
             }
         } else if (isWheelPointer(event)) {
@@ -65,6 +70,11 @@ export function withHandPointer<T extends PlaitBoard>(board: T) {
     board.pointerMove = (event: PointerEvent) => {
         const options = (board as unknown as PlaitOptionsBoard).getPluginOptions<WithHandPluginOptions>(PlaitPluginKey.withHand);
         const triggerDistance = DRAG_SELECTION_PRESS_AND_MOVE_BUFFER + 4;
+        const canEnterHandMode =
+            options?.isHandMode(board, event) ||
+            PlaitBoard.isPointer(board, PlaitPointerType.hand) ||
+            hasWheelPressed ||
+            hasSecondaryPressed;
 
         if (hasSecondaryPressed && movingPoint && !isHandMoving && pointerDownEvent) {
             const distance = distanceBetweenPointAndPoint(pointerDownEvent.x, pointerDownEvent.y, event.x, event.y);
@@ -76,6 +86,7 @@ export function withHandPointer<T extends PlaitBoard>(board: T) {
         if (
             movingPoint &&
             !isHandMoving &&
+            canEnterHandMode &&
             !isSelectionMoving(board) &&
             pointerDownEvent &&
             distanceBetweenPointAndPoint(pointerDownEvent.x, pointerDownEvent.y, event.x, event.y) > triggerDistance &&
@@ -83,13 +94,6 @@ export function withHandPointer<T extends PlaitBoard>(board: T) {
         ) {
             enterHandMode();
         }
-
-        const canEnterHandMode =
-            options?.isHandMode(board, event) ||
-            PlaitBoard.isPointer(board, PlaitPointerType.hand) ||
-            hasWheelPressed ||
-            hasSecondaryPressed ||
-            beingPressedShortcutKey;
 
         if (canEnterHandMode && isHandMoving && movingPoint && !isSelectionMoving(board) && !isMovingElements(board)) {
             const viewportContainer = PlaitBoard.getViewportContainer(board);
@@ -103,13 +107,15 @@ export function withHandPointer<T extends PlaitBoard>(board: T) {
     };
 
     board.pointerUp = (event: PointerEvent) => {
-        if (isHandMoving) {
+        isMainPointerPressed = false;
+        if (isHandMoving || isShortcutPointerDown) {
             return;
         }
         pointerUp(event);
     };
 
     board.globalPointerUp = (event: PointerEvent) => {
+        isMainPointerPressed = false;
         if (movingPoint) {
             movingPoint = null;
         }
@@ -117,13 +123,30 @@ export function withHandPointer<T extends PlaitBoard>(board: T) {
         hasWheelPressed = false;
         hasSecondaryPressed = false;
         globalPointerUp(event);
+        isShortcutPointerDown = false;
+        if (!isShortcutKeyPressed) {
+            BOARD_TO_TEMPORARY_POINTER.delete(board);
+        }
+    };
+
+    board.pointerCancel = (event: PointerEvent) => {
+        pointerCancel(event);
+        isMainPointerPressed = false;
+        movingPoint = null;
+        exitHandMode();
+        hasWheelPressed = false;
+        hasSecondaryPressed = false;
+        isShortcutPointerDown = false;
+        if (!isShortcutKeyPressed) {
+            BOARD_TO_TEMPORARY_POINTER.delete(board);
+        }
     };
 
     board.keyDown = (event: KeyboardEvent) => {
         if (event.code === ShortcutKey) {
-            if (!board.options.readonly && !PlaitBoard.isPointer(board, PlaitPointerType.hand)) {
-                beingPressedShortcutKey = true;
-                setSelectionOptions(board, { isDisabledSelection: true });
+            if (!board.options.readonly && !isMainPointerPressed && board.pointer !== PlaitPointerType.hand) {
+                isShortcutKeyPressed = true;
+                BOARD_TO_TEMPORARY_POINTER.set(board, PlaitPointerType.hand);
                 PlaitBoard.getBoardContainer(board).classList.add('viewport-moving');
             }
             event.preventDefault();
@@ -132,10 +155,12 @@ export function withHandPointer<T extends PlaitBoard>(board: T) {
     };
 
     board.keyUp = (event: KeyboardEvent) => {
-        if (!board.options.readonly && event.code === ShortcutKey) {
-            beingPressedShortcutKey = false;
-            setSelectionOptions(board, { isDisabledSelection: false });
-            PlaitBoard.getBoardContainer(board).classList.remove('viewport-moving');
+        if (event.code === ShortcutKey) {
+            isShortcutKeyPressed = false;
+            if (!isShortcutPointerDown) {
+                BOARD_TO_TEMPORARY_POINTER.delete(board);
+                PlaitBoard.getBoardContainer(board).classList.remove('viewport-moving');
+            }
         }
         keyUp(event);
     };

--- a/packages/core/src/plugins/with-selection.spec.ts
+++ b/packages/core/src/plugins/with-selection.spec.ts
@@ -1,8 +1,8 @@
 import { fakeAsync, tick } from '@angular/core/testing';
 import { PlaitBoard, PlaitElement, PlaitPointerType } from '../interfaces';
-import { clearNodeWeakMap, createTestingBoard, fakeNodeWeakMap } from '../testing';
+import { clearBoardElementHost, clearNodeWeakMap, createTestingBoard, fakeBoardElementHost, fakeNodeWeakMap } from '../testing';
 import { Transforms } from '../transforms';
-import { BOARD_TO_ELEMENT_HOST, cacheSelectedElements, getSelectedElements } from '../utils';
+import { cacheSelectedElements, createG, getSelectedElements } from '../utils';
 import { withOptions } from './with-options';
 import { withSelection } from './with-selection';
 
@@ -10,8 +10,6 @@ const children: PlaitElement[] = [
     { id: 'first', type: 'geometry' },
     { id: 'second', type: 'geometry' }
 ];
-
-const createG = () => document.createElementNS('http://www.w3.org/2000/svg', 'g');
 
 describe('withSelection', () => {
     let board: PlaitBoard;
@@ -21,23 +19,14 @@ describe('withSelection', () => {
     beforeEach(() => {
         board = createTestingBoard([withOptions, withSelection], children);
         fakeNodeWeakMap(board);
-        activeHost = createG();
-        BOARD_TO_ELEMENT_HOST.set(board, {
-            lowerHost: createG(),
-            host: createG(),
-            upperHost: createG(),
-            topHost: createG(),
-            activeHost,
-            container: document.createElement('div'),
-            viewportContainer: document.createElement('div')
-        });
+        activeHost = fakeBoardElementHost(board).activeHost;
         drawSelectionRectangle = jasmine.createSpy('drawSelectionRectangle').and.callFake(() => createG());
         board.drawSelectionRectangle = drawSelectionRectangle;
     });
 
     afterEach(() => {
         clearNodeWeakMap(board);
-        BOARD_TO_ELEMENT_HOST.delete(board);
+        clearBoardElementHost(board);
     });
 
     it('should refresh the multi-selection rectangle after viewport changes in hand mode', fakeAsync(() => {

--- a/packages/core/src/testing/core/fake-weak-map.ts
+++ b/packages/core/src/testing/core/fake-weak-map.ts
@@ -1,6 +1,7 @@
 import { PlaitBoard } from '../../interfaces/board';
 import { PlaitNode } from '../../interfaces/node';
-import { NODE_TO_INDEX, NODE_TO_PARENT } from '../../utils/weak-maps';
+import { createG } from '../../utils/dom/common';
+import { BOARD_TO_ELEMENT_HOST, NODE_TO_INDEX, NODE_TO_PARENT } from '../../utils/weak-maps';
 
 export const fakeNodeWeakMap = (object: PlaitNode | PlaitBoard) => {
     const children = object.children || [];
@@ -18,4 +19,22 @@ export const clearNodeWeakMap = (object: PlaitNode | PlaitBoard) => {
         NODE_TO_INDEX.delete(value);
         clearNodeWeakMap(value);
     });
+};
+
+export const fakeBoardElementHost = (board: PlaitBoard) => {
+    const elementHost = {
+        lowerHost: createG(),
+        host: createG(),
+        upperHost: createG(),
+        topHost: createG(),
+        activeHost: createG(),
+        container: document.createElement('div'),
+        viewportContainer: document.createElement('div')
+    };
+    BOARD_TO_ELEMENT_HOST.set(board, elementHost);
+    return elementHost;
+};
+
+export const clearBoardElementHost = (board: PlaitBoard) => {
+    BOARD_TO_ELEMENT_HOST.delete(board);
 };

--- a/packages/core/src/testing/fake-events/event-objects.ts
+++ b/packages/core/src/testing/fake-events/event-objects.ts
@@ -125,10 +125,16 @@ export function createTouchEvent(type: string, pageX = 0, pageY = 0, clientX = 0
 }
 
 /**
- * Creates a keyboard event with the specified key and modifiers.
+ * Creates a keyboard event with the specified key, code and modifiers.
  * @docs-private
  */
-export function createKeyboardEvent(type: string, keyCode: number = 0, key: string = '', modifiers: ModifierKeys = {}) {
+export function createKeyboardEvent(
+    type: string,
+    keyCode: number = 0,
+    key: string = '',
+    modifiers: ModifierKeys = {},
+    code: string = ''
+) {
     return new KeyboardEvent(type, {
         bubbles: true,
         cancelable: true,
@@ -136,6 +142,7 @@ export function createKeyboardEvent(type: string, keyCode: number = 0, key: stri
         view: window,
         keyCode: keyCode,
         key: key,
+        code: code,
         shiftKey: modifiers.shift,
         metaKey: modifiers.meta,
         altKey: modifiers.alt,

--- a/packages/core/src/utils/weak-maps.ts
+++ b/packages/core/src/utils/weak-maps.ts
@@ -55,6 +55,8 @@ export const BOARD_TO_MOVING_POINT_IN_BOARD = new WeakMap<PlaitBoard, Point>();
 
 export const BOARD_TO_MOVING_POINT = new WeakMap<PlaitBoard, Point>();
 
+export const BOARD_TO_TEMPORARY_POINTER = new WeakMap<PlaitBoard, string>();
+
 export const BOARD_TO_VIEWPORT_ORIGINATION = new WeakMap<PlaitBoard, Point>();
 
 export const BOARD_TO_IS_SELECTION_MOVING = new WeakMap<PlaitBoard, boolean>();

--- a/packages/draw/src/utils/swimlane.spec.ts
+++ b/packages/draw/src/utils/swimlane.spec.ts
@@ -1,0 +1,22 @@
+import { BOARD_TO_TEMPORARY_POINTER, createTestingBoard, PlaitBoard, PlaitPointerType } from '@plait/core';
+import { SwimlaneDrawSymbols } from '../interfaces';
+import { isSwimlanePointers } from './swimlane';
+
+describe('isSwimlanePointers', () => {
+    let board: PlaitBoard;
+
+    afterEach(() => {
+        BOARD_TO_TEMPORARY_POINTER.delete(board);
+    });
+
+    it('uses the effective pointer by default', () => {
+        board = createTestingBoard([], []);
+        board.pointer = SwimlaneDrawSymbols.swimlaneHorizontal;
+
+        expect(isSwimlanePointers(board)).toBeTrue();
+
+        BOARD_TO_TEMPORARY_POINTER.set(board, PlaitPointerType.hand);
+
+        expect(isSwimlanePointers(board)).toBeFalse();
+    });
+});

--- a/packages/draw/src/utils/swimlane.ts
+++ b/packages/draw/src/utils/swimlane.ts
@@ -140,6 +140,6 @@ export const adjustSwimlaneShape = (shape: SwimlaneDrawSymbols): SwimlaneSymbols
         : SwimlaneSymbols.swimlaneVertical;
 };
 
-export const isSwimlanePointers = (board: PlaitBoard, pointer: string = board.pointer) => {
+export const isSwimlanePointers = (board: PlaitBoard, pointer: string = PlaitBoard.getPointer(board)) => {
     return getSwimlanePointers().includes(pointer);
 };


### PR DESCRIPTION
Following the discussion in plait-board/drawnix#448, this treats Space as a temporary hand pointer without changing the selected tool. This keeps the active tool from receiving the same pointer gesture while the viewport is being panned, and restores it when the gesture ends.

It also covers release order, active pointer interactions, selection overlays, and swimlane pointer checks.

Tests:
- `ng test core` (64 passed)
- `ng test draw` (31 passed)
