### PR TITLE
fix(common): flush pending resize frame on pointer up

### DIFF
--- a/packages/common/src/plugins/with-resize.ts
+++ b/packages/common/src/plugins/with-resize.ts
@@ -5,6 +5,7 @@ import {
     PlaitPointerType,
     Point,
     distanceBetweenPointAndPoint,
+    flushThrottleRAF,
     isMainPointer,
     throttleRAF,
     toViewBoxPoint,
@@ -20,6 +21,8 @@ const generalCanResize = (board: PlaitBoard, event: PointerEvent) => {
         !PlaitBoard.isReadonly(board) && !PlaitBoard.hasBeenTextEditing(board) && PlaitBoard.isPointer(board, PlaitPointerType.selection)
     );
 };
+
+const RESIZE_RAF_KEY = 'with-common-resize';
 
 export const withResize = <T extends PlaitElementOrArray = PlaitElementOrArray, K = ResizeHandle, P = ResizeOptions>(
     board: PlaitBoard,
@@ -102,7 +105,7 @@ export const withResize = <T extends PlaitElementOrArray = PlaitElementOrArray, 
             if (startPoint && isResizing(board)) {
                 event.preventDefault();
                 const endPoint = toViewBoxPoint(board, toHostPoint(board, event.x, event.y));
-                throttleRAF(board, 'with-common-resize', () => {
+                throttleRAF(board, RESIZE_RAF_KEY, () => {
                     if (startPoint && resizeRef) {
                         options.onResize(resizeRef, {
                             startPoint: toViewBoxPoint(board, toHostPoint(board, startPoint[0], startPoint[1])),
@@ -118,6 +121,9 @@ export const withResize = <T extends PlaitElementOrArray = PlaitElementOrArray, 
     };
 
     board.globalPointerUp = (event: PointerEvent) => {
+        if (isResizing(board)) {
+            flushThrottleRAF(board, RESIZE_RAF_KEY);
+        }
         globalPointerUp(event);
         if (isResizing(board) || resizeHitTestRef) {
             options.afterResize && options.afterResize(resizeRef!);

--- a/packages/core/src/utils/common.spec.ts
+++ b/packages/core/src/utils/common.spec.ts
@@ -1,5 +1,7 @@
 import { fakeAsync, tick } from '@angular/core/testing';
-import { debounce } from './common';
+import { createTestingBoard } from '../testing';
+import { IS_BOARD_ALIVE } from './weak-maps';
+import { debounce, flushThrottleRAF, throttleRAF } from './common';
 
 describe('debounce', () => {
     let func: jasmine.Spy;
@@ -42,5 +44,38 @@ describe('debounce', () => {
         expect(func).toHaveBeenCalledTimes(1);
         tick(wait);
         expect(func).toHaveBeenCalledTimes(2);
+    }));
+});
+
+describe('throttleRAF', () => {
+    it('should synchronously flush the pending callback once', fakeAsync(() => {
+        const board = createTestingBoard([], []);
+        const callback = jasmine.createSpy('callback');
+        IS_BOARD_ALIVE.set(board, true);
+
+        throttleRAF(board, 'test', callback);
+        flushThrottleRAF(board, 'test');
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        tick(16);
+        expect(callback).toHaveBeenCalledTimes(1);
+        IS_BOARD_ALIVE.delete(board);
+    }));
+
+    it('should flush only the latest pending callback', fakeAsync(() => {
+        const board = createTestingBoard([], []);
+        const firstCallback = jasmine.createSpy('firstCallback');
+        const latestCallback = jasmine.createSpy('latestCallback');
+        IS_BOARD_ALIVE.set(board, true);
+
+        throttleRAF(board, 'test', firstCallback);
+        throttleRAF(board, 'test', latestCallback);
+        flushThrottleRAF(board, 'test');
+
+        expect(firstCallback).not.toHaveBeenCalled();
+        expect(latestCallback).toHaveBeenCalledTimes(1);
+        tick(16);
+        expect(latestCallback).toHaveBeenCalledTimes(1);
+        IS_BOARD_ALIVE.delete(board);
     }));
 });

--- a/packages/core/src/utils/common.ts
+++ b/packages/core/src/utils/common.ts
@@ -3,14 +3,19 @@ import { PlaitBoard } from '../interfaces/board';
 import { NodeTransforms } from '../transforms/node';
 import { sortElements } from './position';
 
-const BOARD_TO_RAF = new WeakMap<PlaitBoard, { [key: string]: number | null }>();
+interface RAFTask {
+    timerId: number;
+    callback: () => void;
+}
+
+const BOARD_TO_RAF = new WeakMap<PlaitBoard, { [key: string]: RAFTask | null }>();
 
 export interface MoveNodeOption {
     element: PlaitElement;
     newPath: Path;
 }
 
-const getTimerId = (board: PlaitBoard, key: string) => {
+const getRAFTask = (board: PlaitBoard, key: string) => {
     const state = getRAFState(board);
     return state[key] || null;
 };
@@ -21,21 +26,37 @@ const getRAFState = (board: PlaitBoard) => {
 
 export const throttleRAF = (board: PlaitBoard, key: string, fn: () => void) => {
     const scheduleFunc = () => {
-        let timerId = requestAnimationFrame(() => {
+        const task: RAFTask = {
+            timerId: 0,
+            callback: fn
+        };
+        task.timerId = requestAnimationFrame(() => {
             const value = BOARD_TO_RAF.get(board) || {};
             value[key] = null;
             BOARD_TO_RAF.set(board, value);
-            PlaitBoard.isAlive(board) && fn();
+            PlaitBoard.isAlive(board) && task.callback();
         });
         const state = getRAFState(board);
-        state[key] = timerId;
+        state[key] = task;
         BOARD_TO_RAF.set(board, state);
     };
-    let timerId = getTimerId(board, key);
-    if (timerId !== null) {
-        cancelAnimationFrame(timerId);
+    const task = getRAFTask(board, key);
+    if (task !== null) {
+        cancelAnimationFrame(task.timerId);
     }
     scheduleFunc();
+};
+
+export const flushThrottleRAF = (board: PlaitBoard, key: string) => {
+    const task = getRAFTask(board, key);
+    if (task === null) {
+        return;
+    }
+    cancelAnimationFrame(task.timerId);
+    const state = getRAFState(board);
+    state[key] = null;
+    BOARD_TO_RAF.set(board, state);
+    PlaitBoard.isAlive(board) && task.callback();
 };
 
 export const debounce = <T>(func: (args?: T) => void, wait: number, options?: { leading: boolean }) => {


### PR DESCRIPTION
## Summary

- add a flush API for pending `throttleRAF` callbacks
- flush the pending common resize frame before pointer-up cleanup
- cover synchronous flushing, single execution, and latest-callback behavior

## Root Cause

`withResize` schedules resize work through `requestAnimationFrame`. If `globalPointerUp` runs before the pending frame, it clears `startPoint` and `resizeRef`; the queued callback then observes empty resize state and drops the user's final pointer move.

## Impact

The last resize position is now applied before the resize lifecycle is finalized. This keeps the behavior generic for every consumer of `withResize` and avoids table-specific state management. This was identified while reviewing #1160.

## Verification

- `./node_modules/.bin/tsc -p packages/core/tsconfig.spec.json --noEmit`
- `npm run build:core`
- `npm run build:common`
- `npm run test:core -- --watch=false --browsers=ChromeHeadlessCI --progress=false --include=packages/core/src/utils/common.spec.ts` *(blocked during the Angular/esbuild build phase by an esbuild deadlock, exit 134; specs did not start)*
