### PR TITLE
fix(docs): remove duplicate https in zh-CN online example links

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,10 +35,10 @@ Plait 底层不依赖任何前端 UI 框架，但是它为集成到主流的前�
 
 ![online demo screen](https://github.com/worktile/plait/blob/develop/.docgeni/public/assets/mind-draw-flow.gif?raw=true)
 
--   👉 [在线示例 (流程图)](https://https://plait.pages.dev?init=draw)
--   👉 [在线示例 (思维导图)](https://https://plait.pages.dev?init=mind)
--   👉 [在线示例 (图形可视化)](https://https://plait.pages.dev/graph-viz?init=force-atlas)
--   👉 [在线示例 (流程控制)](https://https://plait.pages.dev/flow)
+-   👉 [在线示例 (流程图)](https://plait.pages.dev?init=draw)
+-   👉 [在线示例 (思维导图)](https://plait.pages.dev?init=mind)
+-   👉 [在线示例 (图形可视化)](https://plait.pages.dev/graph-viz?init=force-atlas)
+-   👉 [在线示例 (流程控制)](https://plait.pages.dev/flow)
 -   👉 [在线文档](https://plait-docs.pages.dev)
 
 #### 框架特性


### PR DESCRIPTION
## Summary

Fix the online example links in README.zh-CN.md. Four URLs were
incorrectly prefixed with an extra "https://" (e.g.
`https://https://plait.pages.dev?init=draw`), which made them
unopenable. Removed the duplicate scheme so they match the links in
the English README.md.

This is a documentation-only change; no `@plait/*` package is affected.

## Related Issue

N/A

## Validation

- [x] Applicable checks pass: lint, build, and tests
- [x] Relevant documentation and examples were verified or are not applicable

Evidence and compatibility notes:

The corrected URLs now match the English README.md and open correctly:
- https://plait.pages.dev?init=draw
- https://plait.pages.dev?init=mind
- https://plait.pages.dev/graph-viz?init=force-atlas
- https://plait.pages.dev/flow

No public API, behavior, or data compatibility impact.

## Changeset

- [ ] A changeset was added when required
- [x] No changeset is required

## AI Assistance

Did you use AI tools to generate or substantially modify code, tests, or documentation in this pull request?

- [x] No
- [ ] Yes

If yes:

- **Tool/model:**
- **AI-assisted work:**
- **My review and validation:**

- [x] I reviewed and understand the AI-assisted changes and can explain and maintain them

## Checklist

- [x] The title and description are in English, and the change is focused
- [x] I reviewed and understand every submitted change
- [x] Tests, documentation, and examples were updated when needed
- [x] Public API and data compatibility were considered
